### PR TITLE
Refactor layoutAttributesForElements to do proper dequeing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode9
+osx_image: xcode9.2
 language: objective-c
 
 script:

--- a/Blueprints.xcodeproj/project.pbxproj
+++ b/Blueprints.xcodeproj/project.pbxproj
@@ -42,6 +42,12 @@
 		BDB4B6CD204CB36300971F64 /* DefaultLayoutAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB4B6CC204CB36300971F64 /* DefaultLayoutAnimator.swift */; };
 		BDB4B6CE204CB36300971F64 /* DefaultLayoutAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB4B6CC204CB36300971F64 /* DefaultLayoutAnimator.swift */; };
 		BDB4B6CF204CB36300971F64 /* DefaultLayoutAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB4B6CC204CB36300971F64 /* DefaultLayoutAnimator.swift */; };
+		BDD0C01220570D5B005493DC /* VerticalBlueprintLayoutTests+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD0C01120570D5B005493DC /* VerticalBlueprintLayoutTests+macOS.swift */; };
+		BDD0C01420570D8D005493DC /* HorizontalBlueprintLayoutTests+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD0C01320570D8D005493DC /* HorizontalBlueprintLayoutTests+macOS.swift */; };
+		BDD0C01720570E85005493DC /* HorizontalBlueprintLayoutTests+iOS+tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD0C01520570E85005493DC /* HorizontalBlueprintLayoutTests+iOS+tvOS.swift */; };
+		BDD0C01820570E85005493DC /* HorizontalBlueprintLayoutTests+iOS+tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD0C01520570E85005493DC /* HorizontalBlueprintLayoutTests+iOS+tvOS.swift */; };
+		BDD0C01920570E85005493DC /* VerticalBlueprintLayoutTests+iOS+tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD0C01620570E85005493DC /* VerticalBlueprintLayoutTests+iOS+tvOS.swift */; };
+		BDD0C01A20570E85005493DC /* VerticalBlueprintLayoutTests+iOS+tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD0C01620570E85005493DC /* VerticalBlueprintLayoutTests+iOS+tvOS.swift */; };
 		BDD5F8CA204C7CD500A6BFD5 /* BlueprintLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD5F8C9204C7CD500A6BFD5 /* BlueprintLayout.swift */; };
 		BDD5F8CC204C7D4A00A6BFD5 /* VerticalBlueprintLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD5F8CB204C7D4A00A6BFD5 /* VerticalBlueprintLayout.swift */; };
 		BDD5F8CD204C7D4A00A6BFD5 /* VerticalBlueprintLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD5F8CB204C7D4A00A6BFD5 /* VerticalBlueprintLayout.swift */; };
@@ -120,6 +126,10 @@
 		BDB4B6C6204CB21000971F64 /* BlueprintLayoutAnimator+iOS+tvOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlueprintLayoutAnimator+iOS+tvOS.swift"; sourceTree = "<group>"; };
 		BDB4B6CA204CB25100971F64 /* BlueprintLayoutAnimator+macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlueprintLayoutAnimator+macOS.swift"; sourceTree = "<group>"; };
 		BDB4B6CC204CB36300971F64 /* DefaultLayoutAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLayoutAnimator.swift; sourceTree = "<group>"; };
+		BDD0C01120570D5B005493DC /* VerticalBlueprintLayoutTests+macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VerticalBlueprintLayoutTests+macOS.swift"; sourceTree = "<group>"; };
+		BDD0C01320570D8D005493DC /* HorizontalBlueprintLayoutTests+macOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "HorizontalBlueprintLayoutTests+macOS.swift"; sourceTree = "<group>"; };
+		BDD0C01520570E85005493DC /* HorizontalBlueprintLayoutTests+iOS+tvOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "HorizontalBlueprintLayoutTests+iOS+tvOS.swift"; sourceTree = "<group>"; };
+		BDD0C01620570E85005493DC /* VerticalBlueprintLayoutTests+iOS+tvOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VerticalBlueprintLayoutTests+iOS+tvOS.swift"; sourceTree = "<group>"; };
 		BDD5F8C9204C7CD500A6BFD5 /* BlueprintLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlueprintLayout.swift; sourceTree = "<group>"; };
 		BDD5F8CB204C7D4A00A6BFD5 /* VerticalBlueprintLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalBlueprintLayout.swift; sourceTree = "<group>"; };
 		BDFB454720559EAC008E59EA /* BlueprintSupplementaryKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlueprintSupplementaryKind.swift; sourceTree = "<group>"; };
@@ -235,7 +245,9 @@
 			isa = PBXGroup;
 			children = (
 				BDB38706204D46960080C93B /* Helper.swift */,
+				BDD0C01320570D8D005493DC /* HorizontalBlueprintLayoutTests+macOS.swift */,
 				BDB38708204D46BB0080C93B /* Mocks.swift */,
+				BDD0C01120570D5B005493DC /* VerticalBlueprintLayoutTests+macOS.swift */,
 			);
 			path = macOS;
 			sourceTree = "<group>";
@@ -254,7 +266,9 @@
 			isa = PBXGroup;
 			children = (
 				BDB38700204D45B50080C93B /* Helper.swift */,
+				BDD0C01520570E85005493DC /* HorizontalBlueprintLayoutTests+iOS+tvOS.swift */,
 				BDB38703204D46400080C93B /* Mocks.swift */,
+				BDD0C01620570E85005493DC /* VerticalBlueprintLayoutTests+iOS+tvOS.swift */,
 			);
 			path = "iOS+tvOS";
 			sourceTree = "<group>";
@@ -651,6 +665,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				BDFB637D204D4B3300D863E3 /* VerticalBlueprintLayoutTests.swift in Sources */,
+				BDD0C01820570E85005493DC /* HorizontalBlueprintLayoutTests+iOS+tvOS.swift in Sources */,
+				BDD0C01A20570E85005493DC /* VerticalBlueprintLayoutTests+iOS+tvOS.swift in Sources */,
 				BDB38702204D45B50080C93B /* Helper.swift in Sources */,
 				BDB38705204D46400080C93B /* Mocks.swift in Sources */,
 				BDB3870A204D46CC0080C93B /* HorizontalBlueprintLayoutTests.swift in Sources */,
@@ -698,6 +714,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				BDB38701204D45B50080C93B /* Helper.swift in Sources */,
+				BDD0C01720570E85005493DC /* HorizontalBlueprintLayoutTests+iOS+tvOS.swift in Sources */,
+				BDD0C01920570E85005493DC /* VerticalBlueprintLayoutTests+iOS+tvOS.swift in Sources */,
 				BDB386FD204D44870080C93B /* HorizontalBlueprintLayoutTests.swift in Sources */,
 				BDFB6382204D782A00D863E3 /* BlueprintLayoutAnimatorTests.swift in Sources */,
 				BDB38704204D46400080C93B /* Mocks.swift in Sources */,
@@ -731,9 +749,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				BDB386FC204D44870080C93B /* HorizontalBlueprintLayoutTests.swift in Sources */,
+				BDD0C01220570D5B005493DC /* VerticalBlueprintLayoutTests+macOS.swift in Sources */,
 				BDB38707204D46960080C93B /* Helper.swift in Sources */,
 				BDB38709204D46BB0080C93B /* Mocks.swift in Sources */,
 				BDFB637C204D4B3300D863E3 /* VerticalBlueprintLayoutTests.swift in Sources */,
+				BDD0C01420570D8D005493DC /* HorizontalBlueprintLayoutTests+macOS.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Shared/BlueprintLayout.swift
+++ b/Sources/Shared/BlueprintLayout.swift
@@ -130,7 +130,16 @@ open class BlueprintLayout : CollectionViewFlowLayout {
   /// - Parameter rect: The rectangle (specified in the collection view’s coordinate system) containing the target views.
   /// - Returns: An array of layout attribute objects containing the layout information for the enclosed items and views.
   override open func layoutAttributesForElements(in rect: CGRect) -> LayoutAttributesForElements {
-    return layoutAttributes.flatMap { $0 }.filter { $0.frame.intersects(rect) }
+    #if os(macOS)
+      /// On macOS, the collection view is the document view of a scroll view, to get proper dequeuing we need to resolve
+      /// the scroll views rectangle instead of the rectangle that is passed to the collection view layout.
+      /// This way we make sure that we never allocate more items than necessary.
+      guard let rect = collectionView?.enclosingScrollView?.documentVisibleRect else {
+        return []
+      }
+    #endif
+
+    return layoutAttributes.flatMap{ $0 }.filter { $0.frame.intersects(rect) }
   }
 
   /// Returns the starting layout information for an item being inserted into the collection view.

--- a/Tests/Shared/HorizontalBlueprintLayoutTests.swift
+++ b/Tests/Shared/HorizontalBlueprintLayoutTests.swift
@@ -34,13 +34,6 @@ class HorizontalBlueprintLayoutTests: XCTestCase {
 
     XCTAssertEqual(horizontalLayout.collectionViewContentSize, CGSize(width: 690, height: 70))
     XCTAssertEqual(horizontalLayout.contentSize, horizontalLayout.collectionViewContentSize)
-
-    #if !os(macOS)
-    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 50, y: 0), size: .init(width: 50, height: 50)))?.count, 1)
-    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 75, y: 0), size: .init(width: 50, height: 50)))?.count, 2)
-    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 100, y: 0), size: .init(width: 50, height: 50)))?.count, 1)
-    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: CGRect(origin: .zero, size: .init(width: 640, height: 50)))?.count, 10)
-    #endif
   }
 
   func testHorizontalLayoutAttributesWithItemsPerRow() {

--- a/Tests/Shared/VerticalBlueprintLayoutTests.swift
+++ b/Tests/Shared/VerticalBlueprintLayoutTests.swift
@@ -33,12 +33,6 @@ class VerticalBlueprintLayoutTests: XCTestCase {
 
     XCTAssertEqual(verticalLayout.collectionViewContentSize, CGSize(width: 200, height: 250))
     XCTAssertEqual(verticalLayout.contentSize, verticalLayout.collectionViewContentSize)
-
-    #if !os(macOS)
-    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: CGRect(origin: .zero, size: .init(width: 50, height: 50)))?.count, 1)
-    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 0, y: 25), size: .init(width: 50, height: 50)))?.count, 2)
-    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: CGRect(origin: .zero, size: .init(width: 200, height: 200)))?.count, 10)
-    #endif
   }
 
   func testVerticalLayoutAttributesWithSpanOne() {

--- a/Tests/iOS+tvOS/HorizontalBlueprintLayoutTests+iOS+tvOS.swift
+++ b/Tests/iOS+tvOS/HorizontalBlueprintLayoutTests+iOS+tvOS.swift
@@ -1,0 +1,28 @@
+import XCTest
+import Blueprints
+
+class HorizontalBlueprintLayoutTests_iOS_tvOS: XCTestCase {
+  let dataSource = MockDataSource()
+  var collectionView: CollectionView!
+  var horizontalLayout: HorizontalBlueprintLayout!
+
+  override func setUp() {
+    super.setUp()
+    let (collectionView, layout) = Helper.createHorizontalLayout(dataSource: dataSource)
+    self.collectionView = collectionView
+    self.horizontalLayout = layout
+  }
+
+  func testLayoutAttributesForElements() {
+    horizontalLayout.minimumLineSpacing = 0
+    horizontalLayout.minimumInteritemSpacing = 0
+    horizontalLayout.sectionInset = .init(top: 0, left: 0, bottom: 0, right: 0)
+    horizontalLayout.prepare()
+
+    let size: CGSize = .init(width: 50, height: 50)
+    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 0, y: 0), size: size))?.count, 1)
+    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 75, y: 0), size: size))?.count, 2)
+    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 100, y: 0), size: size))?.count, 1)
+    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 0, y: 0), size: .init(width: 500, height: 500)))?.count, 10)
+  }
+}

--- a/Tests/iOS+tvOS/VerticalBlueprintLayoutTests+iOS+tvOS.swift
+++ b/Tests/iOS+tvOS/VerticalBlueprintLayoutTests+iOS+tvOS.swift
@@ -1,0 +1,31 @@
+import XCTest
+import Blueprints
+
+class VerticalBlueprintLayoutTests_iOS_tvOS: XCTestCase {
+  let dataSource = MockDataSource()
+  var collectionView: CollectionView!
+  var verticalLayout: VerticalBlueprintLayout!
+
+  override func setUp() {
+    super.setUp()
+    let (collectionView, layout) = Helper.createVerticalLayout(dataSource: dataSource)
+    self.collectionView = collectionView
+    self.verticalLayout = layout
+  }
+
+  func testLayoutAttributesForElements() {
+    verticalLayout.minimumLineSpacing = 0
+    verticalLayout.minimumInteritemSpacing = 0
+    verticalLayout.sectionInset = .init(top: 0, left: 0, bottom: 0, right: 0)
+    verticalLayout.prepare()
+
+    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: .zero)?.count, 1)
+
+    let size = CGSize(width: 50, height: 50)
+    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 0, y: 0), size: size))?.count, 1)
+    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 0, y: 25), size: size))?.count, 2)
+    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 0, y: 50), size: size))?.count, 1)
+    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 0, y: 0), size: CGSize(width: 500, height: 500)))?.count, 10)
+  }
+}
+

--- a/Tests/macOS/HorizontalBlueprintLayoutTests+macOS.swift
+++ b/Tests/macOS/HorizontalBlueprintLayoutTests+macOS.swift
@@ -29,7 +29,8 @@ class HorizontalBlueprintLayoutTests_macOS: XCTestCase {
     collectionView.contentOffset = .init(x: 100, y: 0)
     XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: .zero).count, 1)
 
-    collectionView.enclosingScrollView?.frame = collectionView.frame
+    collectionView.enclosingScrollView?.frame.size = CGSize(width: 500, height: 500)
+    collectionView.contentOffset = .init(x: 0, y: 0)
     XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: .zero).count, 10)
   }
 }

--- a/Tests/macOS/HorizontalBlueprintLayoutTests+macOS.swift
+++ b/Tests/macOS/HorizontalBlueprintLayoutTests+macOS.swift
@@ -1,0 +1,35 @@
+import XCTest
+import Blueprints
+
+class HorizontalBlueprintLayoutTests_macOS: XCTestCase {
+  let dataSource = MockDataSource()
+  var collectionView: CollectionView!
+  var horizontalLayout: HorizontalBlueprintLayout!
+
+  override func setUp() {
+    super.setUp()
+    let (collectionView, layout) = Helper.createHorizontalLayout(dataSource: dataSource)
+    self.collectionView = collectionView
+    self.horizontalLayout = layout
+  }
+
+  func testLayoutAttributesForElements() {
+    horizontalLayout.minimumLineSpacing = 0
+    horizontalLayout.minimumInteritemSpacing = 0
+    horizontalLayout.sectionInset = .init(top: 0, left: 0, bottom: 0, right: 0)
+    horizontalLayout.prepare()
+
+    collectionView.enclosingScrollView?.frame.size = .init(width: 50, height: 50)
+    collectionView.contentOffset = .init(x: 0, y: 0)
+    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: .zero).count, 1)
+
+    collectionView.contentOffset = .init(x: 75, y: 0)
+    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: .zero).count, 2)
+
+    collectionView.contentOffset = .init(x: 100, y: 0)
+    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: .zero).count, 1)
+
+    collectionView.enclosingScrollView?.frame = collectionView.frame
+    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: .zero).count, 10)
+  }
+}

--- a/Tests/macOS/VerticalBlueprintLayoutTests+macOS.swift
+++ b/Tests/macOS/VerticalBlueprintLayoutTests+macOS.swift
@@ -29,7 +29,8 @@ class VerticalBlueprintLayoutTests_macOS: XCTestCase {
     collectionView.contentOffset = .init(x: 0, y: 50)
     XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: .zero).count, 1)
 
-    collectionView.enclosingScrollView?.frame.size.height = 500
+    collectionView.enclosingScrollView?.frame.size = CGSize(width: 500, height: 500)
+    collectionView.contentOffset = .init(x: 0, y: 0)
     XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: .zero).count, 10)
   }
 }

--- a/Tests/macOS/VerticalBlueprintLayoutTests+macOS.swift
+++ b/Tests/macOS/VerticalBlueprintLayoutTests+macOS.swift
@@ -1,0 +1,36 @@
+import XCTest
+import Blueprints
+
+class VerticalBlueprintLayoutTests_macOS: XCTestCase {
+  let dataSource = MockDataSource()
+  var collectionView: CollectionView!
+  var verticalLayout: VerticalBlueprintLayout!
+
+  override func setUp() {
+    super.setUp()
+    let (collectionView, layout) = Helper.createVerticalLayout(dataSource: dataSource)
+    self.collectionView = collectionView
+    self.verticalLayout = layout
+  }
+
+  func testLayoutAttributesForElements() {
+    verticalLayout.minimumLineSpacing = 0
+    verticalLayout.minimumInteritemSpacing = 0
+    verticalLayout.sectionInset = .init(top: 0, left: 0, bottom: 0, right: 0)
+    verticalLayout.prepare()
+
+    collectionView.enclosingScrollView?.frame.size = .init(width: 50, height: 50)
+    collectionView.contentOffset = .init(x: 0, y: 0)
+    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: .zero).count, 1)
+
+    collectionView.contentOffset = .init(x: 0, y: 25)
+    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: .zero).count, 2)
+
+    collectionView.contentOffset = .init(x: 0, y: 50)
+    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: .zero).count, 1)
+
+    collectionView.enclosingScrollView?.frame.size.height = 500
+    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: .zero).count, 10)
+  }
+}
+


### PR DESCRIPTION
On macOS, the collection view is the document view of a scroll view, to get proper dequeuing we need to resolve the scroll views rectangle instead of the rectangle that is passed to the collection view layout.

This way we make sure that we never allocate more items than necessary.