### PR TITLE
Fix UI glitch with sticky header & footers on macOS

### DIFF
--- a/Sources/Shared/BlueprintLayout.swift
+++ b/Sources/Shared/BlueprintLayout.swift
@@ -94,10 +94,10 @@ open class BlueprintLayout : CollectionViewFlowLayout {
 
     switch kind {
     case .header:
-      layoutAttribute.size.width = collectionView?.frame.size.width ?? headerReferenceSize.width
+      layoutAttribute.size.width = collectionView?.documentRect.width ?? headerReferenceSize.width
       layoutAttribute.size.height = headerReferenceSize.height
     case .footer:
-      layoutAttribute.size.width = collectionView?.frame.size.width ?? footerReferenceSize.width
+      layoutAttribute.size.width = collectionView?.documentRect.width ?? footerReferenceSize.width
       layoutAttribute.size.height = footerReferenceSize.height
     }
 

--- a/Sources/Shared/VerticalBlueprintLayout.swift
+++ b/Sources/Shared/VerticalBlueprintLayout.swift
@@ -76,7 +76,7 @@ open class VerticalBlueprintLayout: BlueprintLayout {
           indexPath: sectionIndexPath,
           atY: nextY
         )
-        layoutAttribute.frame.size.width = collectionView?.frame.size.width ?? headerReferenceSize.width
+        layoutAttribute.frame.size.width = collectionView?.documentRect.width ?? headerReferenceSize.width
         layoutAttributes.append([layoutAttribute])
         headerAttribute = layoutAttribute
         nextY = layoutAttribute.frame.maxY

--- a/Sources/iOS+tvOS/Extensions/UICollectionView+Extensions.swift
+++ b/Sources/iOS+tvOS/Extensions/UICollectionView+Extensions.swift
@@ -3,4 +3,8 @@ import UIKit
 extension UICollectionView {
   static var collectionViewHeaderType: String { return UICollectionElementKindSectionHeader }
   static var collectionViewFooterType: String { return UICollectionElementKindSectionFooter }
+
+  var documentRect: CGRect {
+    return frame
+  }
 }

--- a/Sources/macOS/Extensions/NSCollectionView+Extensions.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+Extensions.swift
@@ -9,6 +9,10 @@ public extension CollectionView {
     set { scroll(newValue) }
   }
 
+  var documentRect: CGRect {
+    return enclosingScrollView?.documentVisibleRect ?? .zero
+  }
+
   convenience public init(frame: CGRect, collectionViewLayout: CollectionViewFlowLayout) {
     self.init(frame: frame)
     self.collectionViewLayout = collectionViewLayout


### PR DESCRIPTION
The collection views frame can exceed the view bounds which will cause the headers to render incorrectly. Now the width of the headers & footers use the documents visible rectangle of the scroll view instead.