### PR TITLE
Improve/transitioning between layout

### DIFF
--- a/Sources/Shared/TypeAlias.swift
+++ b/Sources/Shared/TypeAlias.swift
@@ -2,6 +2,7 @@
   import Cocoa
   public typealias CollectionView = NSCollectionView
   public typealias CollectionViewElementKind = NSCollectionView.SupplementaryElementKind
+  public typealias CollectionViewLayout = NSCollectionViewLayout
   public typealias CollectionViewFlowLayout = NSCollectionViewFlowLayout
   public typealias CollectionViewFlowLayoutDelegate = NSCollectionViewDelegateFlowLayout
   public typealias CollectionViewUpdateItem = NSCollectionViewUpdateItem
@@ -13,6 +14,7 @@
   import UIKit
   public typealias CollectionView = UICollectionView
   public typealias CollectionViewElementKind = String
+  public typealias CollectionViewLayout = UICollectionViewLayout
   public typealias CollectionViewFlowLayout = UICollectionViewFlowLayout
   public typealias CollectionViewFlowLayoutDelegate = UICollectionViewDelegateFlowLayout
   public typealias CollectionViewUpdateItem = UICollectionViewUpdateItem

--- a/Sources/Shared/VerticalBlueprintLayout.swift
+++ b/Sources/Shared/VerticalBlueprintLayout.swift
@@ -53,7 +53,7 @@ open class VerticalBlueprintLayout: BlueprintLayout {
     var layoutAttributes = self.layoutAttributes
     var threshold: CGFloat = 0.0
 
-    if let collectionViewWidth = collectionView?.frame.size.width {
+    if let collectionViewWidth = collectionView?.documentRect.width {
       threshold = collectionViewWidth
     }
 
@@ -160,7 +160,7 @@ open class VerticalBlueprintLayout: BlueprintLayout {
       firstItem = nil
     }
 
-    contentSize.width = collectionView?.frame.width ?? 0
+    contentSize.width = threshold
     contentSize.height += headerReferenceSize.height + footerReferenceSize.height
 
     self.layoutAttributes = layoutAttributes

--- a/Sources/macOS/Extensions/BlueprintLayout+macOS.swift
+++ b/Sources/macOS/Extensions/BlueprintLayout+macOS.swift
@@ -17,6 +17,11 @@ extension BlueprintLayout {
     return layoutAttributesResult
   }
 
+  open override func finalizeLayoutTransition() {
+    super.finalizeLayoutTransition()
+    collectionView?.enclosingScrollView?.layout()
+  }
+
   func configureHeaderFooterWidth(_ view: NSView) {
     headerFooterWidth = view.frame.width
   }
@@ -26,7 +31,7 @@ extension BlueprintLayout {
       clipView == collectionView?.enclosingScrollView?.contentView else {
         return
     }
-
+    collectionView?.enclosingScrollView?.layout()
     configureHeaderFooterWidth(clipView)
   }
 }


### PR DESCRIPTION
###  Use documentRect instead of frame
The collection view frame might not be what we expect when transitioning between layouts. So instead of relying on the frame, we use `documentRect` which is the scroll views width.

### Refactor BlueprintLayout to handle transitioning
Refactor BlueprintLayout to improve the transition between layouts. The new layout will be properly prepared before it replaces the old layout. This is done in ` prepareForTransition(to newLayout: CollectionViewLayout)`.

This PR mainly focuses on improving layout transitioning on macOS.