### PR TITLE
Add estimatedItemSize to init methods & improve delegate usage.

### DIFF
--- a/Sources/Shared/BlueprintLayout.swift
+++ b/Sources/Shared/BlueprintLayout.swift
@@ -35,6 +35,7 @@ open class BlueprintLayout : CollectionViewFlowLayout {
   public init(
     itemsPerRow: CGFloat? = nil,
     itemSize: CGSize = CGSize(width: 50, height: 50),
+    estimatedItemSize: CGSize = .zero,
     minimumInteritemSpacing: CGFloat = 10,
     minimumLineSpacing: CGFloat = 10,
     sectionInset: EdgeInsets = EdgeInsets(top: 0, left: 0, bottom: 0, right: 0),
@@ -44,6 +45,7 @@ open class BlueprintLayout : CollectionViewFlowLayout {
     self.animator = animator
     super.init()
     self.itemSize = itemSize
+    self.estimatedItemSize = estimatedItemSize
     self.minimumInteritemSpacing = minimumInteritemSpacing
     self.minimumLineSpacing = minimumLineSpacing
     self.sectionInset = sectionInset
@@ -112,9 +114,15 @@ open class BlueprintLayout : CollectionViewFlowLayout {
         containerWidth = collectionView.frame.size.width
       #endif
 
+      let height = resolveCollectionView({ collectionView -> CGSize? in
+        return (collectionView.delegate as? CollectionViewFlowLayoutDelegate)?.collectionView?(collectionView,
+                                                                                               layout: self,
+                                                                                               sizeForItemAt: indexPath)
+      }, defaultValue: itemSize).height
+
       let size = CGSize(
         width: calculateItemWidth(itemsPerRow, containerWidth: containerWidth),
-        height: itemSize.height
+        height: height
       )
 
       return size

--- a/Sources/Shared/HorizontalBlueprintLayout.swift
+++ b/Sources/Shared/HorizontalBlueprintLayout.swift
@@ -28,6 +28,7 @@ open class HorizontalBlueprintLayout: BlueprintLayout {
     itemsPerRow: CGFloat? = nil,
     itemsPerColumn: Int = 1,
     itemSize: CGSize = CGSize(width: 50, height: 50),
+    estimatedItemSize: CGSize = .zero,
     minimumInteritemSpacing: CGFloat = 10,
     minimumLineSpacing: CGFloat = 10,
     sectionInset: EdgeInsets = EdgeInsets(top: 0, left: 0, bottom: 0, right: 0),
@@ -41,6 +42,7 @@ open class HorizontalBlueprintLayout: BlueprintLayout {
     super.init(
       itemsPerRow: itemsPerRow,
       itemSize: itemSize,
+      estimatedItemSize: estimatedItemSize,
       minimumInteritemSpacing: minimumInteritemSpacing,
       minimumLineSpacing: minimumLineSpacing,
       sectionInset: sectionInset,

--- a/Sources/Shared/VerticalBlueprintLayout.swift
+++ b/Sources/Shared/VerticalBlueprintLayout.swift
@@ -24,6 +24,7 @@ open class VerticalBlueprintLayout: BlueprintLayout {
   required public init(
     itemsPerRow: CGFloat? = nil,
     itemSize: CGSize = CGSize(width: 50, height: 50),
+    estimatedItemSize: CGSize = .zero,
     minimumInteritemSpacing: CGFloat = 0,
     minimumLineSpacing: CGFloat = 10,
     sectionInset: EdgeInsets = EdgeInsets(top: 0, left: 0, bottom: 0, right: 0),
@@ -36,6 +37,7 @@ open class VerticalBlueprintLayout: BlueprintLayout {
     super.init(
       itemsPerRow: itemsPerRow,
       itemSize: itemSize,
+      estimatedItemSize: estimatedItemSize,
       minimumInteritemSpacing: minimumInteritemSpacing,
       minimumLineSpacing: minimumLineSpacing,
       sectionInset: sectionInset,


### PR DESCRIPTION
This adds `estimatedItemSize` to init methods on the Blueprints layouts.

It will also resolve the height from the  `CollectionViewFlowLayoutDelegate` when using calculated item widths.