### PR TITLE
Remove mac os optimization

### DIFF
--- a/Sources/Shared/BlueprintLayout.swift
+++ b/Sources/Shared/BlueprintLayout.swift
@@ -263,8 +263,4 @@ open class BlueprintLayout : CollectionViewFlowLayout {
   override open func prepare(forCollectionViewUpdates updateItems: [CollectionViewUpdateItem]) {
     return animator.prepare(forCollectionViewUpdates: updateItems)
   }
-
-  open override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
-    return true
-  }
 }

--- a/Sources/Shared/BlueprintLayout.swift
+++ b/Sources/Shared/BlueprintLayout.swift
@@ -227,13 +227,6 @@ open class BlueprintLayout : CollectionViewFlowLayout {
   /// - Parameter rect: The rectangle (specified in the collection view’s coordinate system) containing the target views.
   /// - Returns: An array of layout attribute objects containing the layout information for the enclosed items and views.
   override open func layoutAttributesForElements(in rect: CGRect) -> LayoutAttributesForElements {
-    #if os(macOS)
-      /// On macOS, the collection view is the document view of a scroll view, to get proper dequeuing we need to resolve
-      /// the scroll views rectangle instead of the rectangle that is passed to the collection view layout.
-      /// This way we make sure that we never allocate more items than necessary.
-      let rect = collectionView?.enclosingScrollView?.documentVisibleRect ?? rect
-    #endif
-
     return layoutAttributes.flatMap{ $0 }.filter { $0.frame.intersects(rect) }
   }
 

--- a/Tests/macOS/HorizontalBlueprintLayoutTests+macOS.swift
+++ b/Tests/macOS/HorizontalBlueprintLayoutTests+macOS.swift
@@ -24,13 +24,13 @@ class HorizontalBlueprintLayoutTests_macOS: XCTestCase {
     XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: .zero).count, 1)
 
     collectionView.contentOffset = .init(x: 75, y: 0)
-    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: .zero).count, 2)
+    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: collectionView.enclosingScrollView!.documentVisibleRect).count, 2)
 
     collectionView.contentOffset = .init(x: 100, y: 0)
-    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: .zero).count, 1)
+    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: collectionView.enclosingScrollView!.documentVisibleRect).count, 1)
 
     collectionView.enclosingScrollView?.frame.size = CGSize(width: 500, height: 500)
     collectionView.contentOffset = .init(x: 0, y: 0)
-    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: .zero).count, 10)
+    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: collectionView.enclosingScrollView!.documentVisibleRect).count, 10)
   }
 }

--- a/Tests/macOS/VerticalBlueprintLayoutTests+macOS.swift
+++ b/Tests/macOS/VerticalBlueprintLayoutTests+macOS.swift
@@ -21,17 +21,17 @@ class VerticalBlueprintLayoutTests_macOS: XCTestCase {
 
     collectionView.enclosingScrollView?.frame.size = .init(width: 50, height: 50)
     collectionView.contentOffset = .init(x: 0, y: 0)
-    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: .zero).count, 1)
+    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: collectionView.enclosingScrollView!.documentVisibleRect).count, 1)
 
     collectionView.contentOffset = .init(x: 0, y: 25)
-    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: .zero).count, 2)
+    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: collectionView.enclosingScrollView!.documentVisibleRect).count, 2)
 
     collectionView.contentOffset = .init(x: 0, y: 50)
-    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: .zero).count, 1)
+    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: collectionView.enclosingScrollView!.documentVisibleRect).count, 1)
 
     collectionView.enclosingScrollView?.frame.size = CGSize(width: 500, height: 500)
     collectionView.contentOffset = .init(x: 0, y: 0)
-    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: .zero).count, 10)
+    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: collectionView.enclosingScrollView!.documentVisibleRect).count, 10)
   }
 }
 


### PR DESCRIPTION
- Scoping the rectangle to the scroll view will have an impact on scrolling performance, the rectangle that is passed into `layoutAttributesForElements` is larger than the viewport in macOS by design, and we should refrain from fighting the system as it could lead to undesired and unexpected behavior.

- Remove implementation for shouldInvalidateLayout