### PR TITLE
Only add header and footer height if content size height is more than zero

### DIFF
--- a/Sources/Shared/HorizontalBlueprintLayout.swift
+++ b/Sources/Shared/HorizontalBlueprintLayout.swift
@@ -165,7 +165,9 @@ open class HorizontalBlueprintLayout: BlueprintLayout {
       firstItem = nil
     }
 
-    contentSize.height += headerReferenceSize.height + footerReferenceSize.height
+    if contentSize.height > 0 {
+      contentSize.height += headerReferenceSize.height + footerReferenceSize.height
+    }
 
     self.layoutAttributes = layoutAttributes
     self.contentSize = contentSize


### PR DESCRIPTION
Fixes issue with adding header and footer heights to empty layouts.