### PR TITLE
Refactor caching of layout attributes

### DIFF
--- a/Sources/Shared/Core/HorizontalBlueprintLayout.swift
+++ b/Sources/Shared/Core/HorizontalBlueprintLayout.swift
@@ -169,7 +169,7 @@ open class HorizontalBlueprintLayout: BlueprintLayout {
       contentSize.height += headerReferenceSize.height + footerReferenceSize.height
     }
 
-    self.cachedAttributes = layoutAttributes
     self.contentSize = contentSize
+    createCache(with: layoutAttributes)
   }
 }

--- a/Sources/Shared/Core/VerticalBlueprintLayout.swift
+++ b/Sources/Shared/Core/VerticalBlueprintLayout.swift
@@ -165,7 +165,8 @@ open class VerticalBlueprintLayout: BlueprintLayout {
     contentSize.width = threshold
     contentSize.height += headerReferenceSize.height + footerReferenceSize.height
 
-    self.cachedAttributes = layoutAttributes
+
     self.contentSize = contentSize
+    createCache(with: layoutAttributes)
   }
 }

--- a/Sources/Shared/Mosaic/VerticalMosaicBlueprintLayout.swift
+++ b/Sources/Shared/Mosaic/VerticalMosaicBlueprintLayout.swift
@@ -96,9 +96,8 @@ public class VerticalMosaicBlueprintLayout: BlueprintLayout {
     }
 
     contentSize.width = threshold
-
-    self.cachedAttributes = layoutAttributes
     self.contentSize = contentSize
+    createCache(with: layoutAttributes)
   }
 
   private func apply(_ pattern: MosaicPattern, to mosaicLayoutAttribute: MosaicLayoutAttributes, with threshold: CGFloat) {

--- a/Sources/Shared/Waterfall/VerticalWaterfallBlueprintLayout.swift
+++ b/Sources/Shared/Waterfall/VerticalWaterfallBlueprintLayout.swift
@@ -74,8 +74,7 @@ public class VerticalWaterfallBlueprintLayout: BlueprintLayout {
     }
 
     contentSize.width = threshold
-
-    self.cachedAttributes = layoutAttributes
     self.contentSize = contentSize
+    createCache(with: layoutAttributes)
   }
 }


### PR DESCRIPTION
Each layout will now call `createCache` in their `prepare` methods. This reduces some `compactMap` operations in methods that need performance.