### PR TITLE
Improve binary search

### DIFF
--- a/Blueprints.podspec
+++ b/Blueprints.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Blueprints"
   s.summary          = "A collection of flow layouts that is meant to make your life easier."
-  s.version          = "0.4.0"
+  s.version          = "0.4.1"
   s.homepage         = "https://github.com/zenangst/Blueprints"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Blueprints.xcodeproj/project.pbxproj
+++ b/Blueprints.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		BDB4B6CD204CB36300971F64 /* DefaultLayoutAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB4B6CC204CB36300971F64 /* DefaultLayoutAnimator.swift */; };
 		BDB4B6CE204CB36300971F64 /* DefaultLayoutAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB4B6CC204CB36300971F64 /* DefaultLayoutAnimator.swift */; };
 		BDB4B6CF204CB36300971F64 /* DefaultLayoutAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB4B6CC204CB36300971F64 /* DefaultLayoutAnimator.swift */; };
+		BDB98DCE20D6E115001C5578 /* PeformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB98DCD20D6E115001C5578 /* PeformanceTests.swift */; };
 		BDC90AF320CFE060007B35E7 /* VerticalMosaicBlueprintLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC90AF220CFE060007B35E7 /* VerticalMosaicBlueprintLayout.swift */; };
 		BDC90AF420CFE060007B35E7 /* VerticalMosaicBlueprintLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC90AF220CFE060007B35E7 /* VerticalMosaicBlueprintLayout.swift */; };
 		BDC90AF520CFE060007B35E7 /* VerticalMosaicBlueprintLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC90AF220CFE060007B35E7 /* VerticalMosaicBlueprintLayout.swift */; };
@@ -153,6 +154,7 @@
 		BDB4B6C6204CB21000971F64 /* BlueprintLayoutAnimator+iOS+tvOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlueprintLayoutAnimator+iOS+tvOS.swift"; sourceTree = "<group>"; };
 		BDB4B6CA204CB25100971F64 /* BlueprintLayoutAnimator+macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlueprintLayoutAnimator+macOS.swift"; sourceTree = "<group>"; };
 		BDB4B6CC204CB36300971F64 /* DefaultLayoutAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLayoutAnimator.swift; sourceTree = "<group>"; };
+		BDB98DCD20D6E115001C5578 /* PeformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeformanceTests.swift; sourceTree = "<group>"; };
 		BDC90AF220CFE060007B35E7 /* VerticalMosaicBlueprintLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalMosaicBlueprintLayout.swift; sourceTree = "<group>"; };
 		BDD0C01120570D5B005493DC /* VerticalBlueprintLayoutTests+macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VerticalBlueprintLayoutTests+macOS.swift"; sourceTree = "<group>"; };
 		BDD0C01320570D8D005493DC /* HorizontalBlueprintLayoutTests+macOS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "HorizontalBlueprintLayoutTests+macOS.swift"; sourceTree = "<group>"; };
@@ -324,6 +326,7 @@
 				BDFB637A204D4B3300D863E3 /* VerticalBlueprintLayoutTests.swift */,
 				BDA31B0B20D41C94001E4870 /* VerticalMosaicBlueprintLayoutTests.swift */,
 				BD10268020D56744004964F7 /* VerticalWaterfallBlueprintLayoutTests.swift */,
+				BDB98DCD20D6E115001C5578 /* PeformanceTests.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -785,6 +788,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BDB38701204D45B50080C93B /* Helper.swift in Sources */,
+				BDB98DCE20D6E115001C5578 /* PeformanceTests.swift in Sources */,
 				BD10268120D56744004964F7 /* VerticalWaterfallBlueprintLayoutTests.swift in Sources */,
 				BDD0C01720570E85005493DC /* HorizontalBlueprintLayoutTests+iOS+tvOS.swift in Sources */,
 				BDD0C01920570E85005493DC /* VerticalBlueprintLayoutTests+iOS+tvOS.swift in Sources */,

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -314,20 +314,20 @@ open class BlueprintLayout : CollectionViewFlowLayout {
       return allCachedAttributes.filter { $0.frame.intersects(rect) }
     }
 
-    for attributes in allCachedAttributes[..<firstMatchIndex] {
+    for attributes in allCachedAttributes[..<firstMatchIndex].reversed() {
       if scrollDirection == .horizontal {
-        guard attributes.frame.minX <= rect.maxX else { break }
+        guard attributes.frame.maxX >= rect.minY else { break }
       } else {
-        guard attributes.frame.minY <= rect.maxY else { break }
+        guard attributes.frame.maxY >= rect.minY else { break }
       }
       attributesArray.append(attributes)
     }
 
     for attributes in allCachedAttributes[firstMatchIndex...] {
       if scrollDirection == .horizontal {
-        guard attributes.frame.minX <= rect.minX else { break }
+        guard attributes.frame.minX <= rect.maxY else { break }
       } else {
-        guard attributes.frame.minY <= rect.minY else { break }
+        guard attributes.frame.minY <= rect.maxY else { break }
       }
       attributesArray.append(attributes)
     }

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -267,11 +267,11 @@ open class BlueprintLayout : CollectionViewFlowLayout {
 
     while lowerBound < upperBound {
       let midIndex = lowerBound + (upperBound - lowerBound) / 2
-      let (rectMax, rectMin, attributeMax, attributeMin) = getMaxMinFrom(layoutAttributes: array[midIndex], rect: rect)
+      let (rectMax, _, _, attributeMin) = getMaxMinFrom(layoutAttributes: array[midIndex], rect: rect)
 
-      if attributeMax >= rectMin {
+      if array[midIndex].frame.intersects(rect) {
         return midIndex
-      } else if attributeMin <= rectMax {
+      } else if attributeMin < rectMax {
         lowerBound = midIndex + 1
       } else {
         upperBound = midIndex

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -267,7 +267,7 @@ open class BlueprintLayout : CollectionViewFlowLayout {
 
     while lowerBound < upperBound {
       let midIndex = lowerBound + (upperBound - lowerBound) / 2
-      let (rectMax, _, _, attributeMin) = getMaxMinFrom(layoutAttributes: array[midIndex], rect: rect)
+      let (rectMax, attributeMin) = getMaxMinFrom(layoutAttributes: array[midIndex], rect: rect)
 
       if array[midIndex].frame.intersects(rect) {
         return midIndex
@@ -281,26 +281,20 @@ open class BlueprintLayout : CollectionViewFlowLayout {
     return nil
   }
 
-  private func getMaxMinFrom(layoutAttributes: LayoutAttributes, rect: CGRect) -> (CGFloat, CGFloat, CGFloat, CGFloat) {
+  private func getMaxMinFrom(layoutAttributes: LayoutAttributes, rect: CGRect) -> (CGFloat, CGFloat) {
     let rectMax: CGFloat
-    let rectMin: CGFloat
-    let attributeMax: CGFloat
     let attributeMin: CGFloat
 
     switch scrollDirection {
     case .horizontal:
-      attributeMax = layoutAttributes.frame.maxX
       attributeMin = layoutAttributes.frame.minX
       rectMax = rect.maxX
-      rectMin = rect.minX
     case .vertical:
-      attributeMax = layoutAttributes.frame.maxY
       attributeMin = layoutAttributes.frame.minY
       rectMax = rect.maxY
-      rectMin = rect.minY
     }
 
-    return (rectMax, rectMin, attributeMax, attributeMin)
+    return (rectMax, attributeMin)
   }
 
   /// Returns the layout attributes for all of the cells and views

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -311,7 +311,7 @@ open class BlueprintLayout : CollectionViewFlowLayout {
   override open func layoutAttributesForElements(in rect: CGRect) -> LayoutAttributesForElements {
     var attributesArray = [LayoutAttributes]()
     guard let firstMatchIndex = binarySearch(allCachedAttributes, rect: rect) else {
-      return attributesArray
+      return allCachedAttributes.filter { $0.frame.intersects(rect) }
     }
 
     for attributes in allCachedAttributes[..<firstMatchIndex] {

--- a/Tests/Shared/PeformanceTests.swift
+++ b/Tests/Shared/PeformanceTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+import Blueprints
+
+class PerformanceTests: XCTestCase {
+  struct Model {}
+
+  class DataSource: NSObject, UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+      return models.count
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+      let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "cell", for: indexPath)
+      return cell
+    }
+
+    var models = [Model]()
+
+    init(amount: Int) {
+      super.init()
+
+      var models = [Model]()
+      for _ in 0..<amount { models.append(Model()) }
+      self.models = models
+    }
+  }
+
+  class LegacyVerticalBlueprintLayout: VerticalBlueprintLayout {
+    override open func layoutAttributesForElements(in rect: CGRect) -> LayoutAttributesForElements {
+      return allCachedAttributes.filter { $0.frame.intersects(rect) }
+    }
+  }
+
+  class LegacyHorizontalBlueprintLayout: HorizontalBlueprintLayout {
+    override open func layoutAttributesForElements(in rect: CGRect) -> LayoutAttributesForElements {
+      return allCachedAttributes.filter { $0.frame.intersects(rect) }
+    }
+  }
+
+  func testPerformanceBetweenLegacyAndNewBinarySearchOnVerticalLayout() {
+    let dataSource = DataSource(amount: 50_000)
+    var layout: BlueprintLayout = LegacyVerticalBlueprintLayout(itemsPerRow: 1,
+                                         itemSize: CGSize(width: 200, height: 60),
+                                         minimumInteritemSpacing: 10,
+                                         minimumLineSpacing: 10,
+                                         sectionInset: .zero)
+    let frame = CGRect(origin: .zero, size: .init(width: 200, height: 200))
+    let collectionView = CollectionView(frame: frame, collectionViewLayout: layout)
+    collectionView.dataSource = dataSource
+    collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "cell")
+    layout.prepare()
+
+    let rect = CGRect(origin: .init(x: 0, y: -200), size: .init(width: 200, height: 400))
+    var startTime = CFAbsoluteTimeGetCurrent()
+    var attributes = layout.layoutAttributesForElements(in: rect)!
+
+    XCTAssertEqual(attributes.count, 3)
+    let legacyBenchmark = CFAbsoluteTimeGetCurrent() - startTime
+    Swift.print("🦀: \(legacyBenchmark)")
+
+    layout = VerticalBlueprintLayout(itemsPerRow: 1,
+                                     itemSize: CGSize(width: 200, height: 60),
+                                     minimumInteritemSpacing: 10,
+                                     minimumLineSpacing: 10,
+                                     sectionInset: .zero)
+    collectionView.collectionViewLayout = layout
+    layout.prepare()
+    startTime = CFAbsoluteTimeGetCurrent()
+
+    attributes = layout.layoutAttributesForElements(in: rect)!
+    XCTAssertEqual(attributes.count, 3)
+    let binarySearchBenchmark = CFAbsoluteTimeGetCurrent() - startTime
+
+    Swift.print("💪: \(binarySearchBenchmark)")
+    XCTAssertTrue(binarySearchBenchmark < legacyBenchmark)
+  }
+
+  func testPerformanceBetweenLegacyAndNewBinarySearchOnHorizontalLayout() {
+    let dataSource = DataSource(amount: 50_000)
+    var layout: BlueprintLayout = LegacyHorizontalBlueprintLayout(itemsPerRow: 3,
+                                                                  itemSize: CGSize(width: 200, height: 60),
+                                                                  minimumInteritemSpacing: 10,
+                                                                  minimumLineSpacing: 10,
+                                                                  sectionInset: .zero)
+    let frame = CGRect(origin: .zero, size: .init(width: 200, height: 200))
+    let collectionView = CollectionView(frame: frame, collectionViewLayout: layout)
+    collectionView.dataSource = dataSource
+    collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "cell")
+    layout.prepare()
+
+    let rect = CGRect(origin: .init(x: 0, y: -200), size: .init(width: 200, height: 400))
+    var startTime = CFAbsoluteTimeGetCurrent()
+    var attributes = layout.layoutAttributesForElements(in: rect)!
+
+    XCTAssertEqual(attributes.count, 3)
+    let legacyBenchmark = CFAbsoluteTimeGetCurrent() - startTime
+    Swift.print("🦀: \(legacyBenchmark)")
+
+    layout = HorizontalBlueprintLayout(itemsPerRow: 3,
+                                       itemSize: CGSize(width: 200, height: 60),
+                                       minimumInteritemSpacing: 10,
+                                       minimumLineSpacing: 10,
+                                       sectionInset: .zero)
+    collectionView.collectionViewLayout = layout
+    layout.prepare()
+    startTime = CFAbsoluteTimeGetCurrent()
+
+    attributes = layout.layoutAttributesForElements(in: rect)!
+    XCTAssertEqual(attributes.count, 3)
+    let binarySearchBenchmark = CFAbsoluteTimeGetCurrent() - startTime
+
+    Swift.print("💪: \(binarySearchBenchmark)")
+    XCTAssertTrue(binarySearchBenchmark < legacyBenchmark)
+  }
+}

--- a/Tests/iOS+tvOS/HorizontalBlueprintLayoutTests+iOS+tvOS.swift
+++ b/Tests/iOS+tvOS/HorizontalBlueprintLayoutTests+iOS+tvOS.swift
@@ -21,8 +21,8 @@ class HorizontalBlueprintLayoutTests_iOS_tvOS: XCTestCase {
 
     let size: CGSize = .init(width: 50, height: 50)
     XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 0, y: 0), size: size))?.count, 2)
-    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 75, y: 0), size: size))?.count, 3)
-    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 100, y: 0), size: size))?.count, 4)
-    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 0, y: 0), size: .init(width: 500, height: 500)))?.count, 5)
+    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 75, y: 0), size: size))?.count, 2)
+    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 100, y: 0), size: size))?.count, 2)
+    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 0, y: 0), size: .init(width: 500, height: 500)))?.count, 10)
   }
 }

--- a/Tests/iOS+tvOS/VerticalBlueprintLayoutTests+iOS+tvOS.swift
+++ b/Tests/iOS+tvOS/VerticalBlueprintLayoutTests+iOS+tvOS.swift
@@ -22,10 +22,10 @@ class VerticalBlueprintLayoutTests_iOS_tvOS: XCTestCase {
     XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: .zero)?.count, 4)
 
     let size = CGSize(width: 50, height: 50)
-    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 0, y: 0), size: size))?.count, 5)
-    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 0, y: 25), size: size))?.count, 5)
-    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 0, y: 50), size: size))?.count, 8)
-    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 0, y: 0), size: CGSize(width: 500, height: 500)))?.count, 5)
+    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 0, y: 0), size: size))?.count, 1)
+    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 0, y: 25), size: size))?.count, 2)
+    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 0, y: 50), size: size))?.count, 1)
+    XCTAssertEqual(verticalLayout.layoutAttributesForElements(in: CGRect(origin: .init(x: 0, y: 0), size: CGSize(width: 500, height: 500)))?.count, 10)
   }
 }
 

--- a/Tests/macOS/HorizontalBlueprintLayoutTests+macOS.swift
+++ b/Tests/macOS/HorizontalBlueprintLayoutTests+macOS.swift
@@ -24,13 +24,13 @@ class HorizontalBlueprintLayoutTests_macOS: XCTestCase {
     XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: .zero).count, 1)
 
     collectionView.contentOffset = .init(x: 75, y: 0)
-    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: collectionView.enclosingScrollView!.documentVisibleRect).count, 3)
+    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: collectionView.enclosingScrollView!.documentVisibleRect).count, 2)
 
     collectionView.contentOffset = .init(x: 100, y: 0)
-    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: collectionView.enclosingScrollView!.documentVisibleRect).count, 4)
+    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: collectionView.enclosingScrollView!.documentVisibleRect).count, 2)
 
     collectionView.enclosingScrollView?.frame.size = CGSize(width: 500, height: 500)
     collectionView.contentOffset = .init(x: 0, y: 0)
-    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: collectionView.enclosingScrollView!.documentVisibleRect).count, 5)
+    XCTAssertEqual(horizontalLayout.layoutAttributesForElements(in: collectionView.enclosingScrollView!.documentVisibleRect).count, 10)
   }
 }


### PR DESCRIPTION
This PR improves how the binary search is implemented.
It uses `intersects` for matching the closest valid layout attribute instead of checking max values against min values on the rectangle.
If there are no matches using the binary search algorithm, `intersects` will be used as a fallback.