### PR TITLE
Fix crash when reloading collection view

### DIFF
--- a/Blueprints.podspec
+++ b/Blueprints.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Blueprints"
   s.summary          = "A collection of flow layouts that is meant to make your life easier."
-  s.version          = "0.7.0"
+  s.version          = "0.7.1"
   s.homepage         = "https://github.com/zenangst/Blueprints"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -16,7 +16,6 @@
   public var cachedAttributes = [[LayoutAttributes]]()
   public var cachedItems = [[LayoutAttributes]]()
   public var allCachedAttributes = [LayoutAttributes]()
-  public var isUpdating: Bool = false
   var binarySearch = BinarySearch()
 
   /// The content size of the layout, should be set using the `prepare` method of any subclass.
@@ -250,10 +249,6 @@
   /// - Parameter indexPath: The index path of the item whose attributes are requested.
   /// - Returns: A layout attributes object containing the information to apply to the item’s cell.
   override open func layoutAttributesForItem(at indexPath: IndexPath) -> LayoutAttributes? {
-    if isUpdating && collectionView?.visibleIndexPaths.contains(indexPath) == false {
-      return nil
-    }
-
     let compare: (LayoutAttributes) -> Bool
     #if os(macOS)
       compare = { indexPath > $0.indexPath! }
@@ -312,7 +307,6 @@
   /// - Parameter updateItems: An array of CollectionViewUpdateItem objects
   //                           that identify the changes being made.
   override open func prepare(forCollectionViewUpdates updateItems: [CollectionViewUpdateItem]) {
-    isUpdating = true
     return animator.prepare(forCollectionViewUpdates: updateItems)
   }
 }

--- a/Sources/iOS+tvOS/Extensions/BlueprintLayout+iOS+tvOS.swift
+++ b/Sources/iOS+tvOS/Extensions/BlueprintLayout+iOS+tvOS.swift
@@ -16,9 +16,4 @@ extension BlueprintLayout {
 
     return layoutAttributesResult
   }
-
-  open override func finalizeLayoutTransition() {
-    super.finalizeLayoutTransition()
-    isUpdating = false
-  }
 }

--- a/Sources/iOS+tvOS/Extensions/BlueprintLayoutAnimator+iOS+tvOS.swift
+++ b/Sources/iOS+tvOS/Extensions/BlueprintLayoutAnimator+iOS+tvOS.swift
@@ -11,3 +11,4 @@ extension BlueprintLayoutAnimator {
     }
   }
 }
+


### PR DESCRIPTION
Remove isUpdating optimization which led to crashes when reloading collection views. The occured because the optimization outed out from returning anything other than `nil` when and update is happening. Internally this caused the collection view to throw an exception when updating a collection view with mutliple inserts and deletions.

Similar to this issue here: https://github.com/ra1028/DifferenceKit/issues/13