### PR TITLE
#40 invalidated layout attributes fix

### DIFF
--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -253,6 +253,10 @@
   /// - Parameter indexPath: The index path of the item whose attributes are requested.
   /// - Returns: A layout attributes object containing the information to apply to the item’s cell.
   override open func layoutAttributesForItem(at indexPath: IndexPath) -> LayoutAttributes? {
+    guard cachedItems.count < 0, indexPath.section < cachedItems.count else {
+        return nil
+    }
+
     let compare: (LayoutAttributes) -> Bool
     #if os(macOS)
       compare = { indexPath > $0.indexPath! }

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -253,9 +253,10 @@
   /// - Parameter indexPath: The index path of the item whose attributes are requested.
   /// - Returns: A layout attributes object containing the information to apply to the item’s cell.
   override open func layoutAttributesForItem(at indexPath: IndexPath) -> LayoutAttributes? {
-    guard cachedItems.count < 0, indexPath.section < cachedItems.count else {
+    guard cachedItems.count > 0, indexPath.section < cachedItems.count else {
         return nil
     }
+    //guard indexPath.section < cachedItems.count else { return nil }
 
     let compare: (LayoutAttributes) -> Bool
     #if os(macOS)
@@ -266,6 +267,7 @@
     let result = binarySearch.findElement(in: cachedItems[indexPath.section],
                                           less: compare,
                                           match: { indexPath == $0.indexPath })
+    print("Results : \(result.debugDescription)")
     return result
   }
 

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -189,6 +189,10 @@
     }
   }
 
+  func indexPathIsOutOfBounds(_ indexPath: IndexPath, for cache: [[LayoutAttributes]]) -> Bool {
+    return !(cache.count > 0 && indexPath.section < cache.count)
+  }
+
   // MARK: - Overrides
 
   /// Tells the layout object to update the current layout.
@@ -253,10 +257,7 @@
   /// - Parameter indexPath: The index path of the item whose attributes are requested.
   /// - Returns: A layout attributes object containing the information to apply to the item’s cell.
   override open func layoutAttributesForItem(at indexPath: IndexPath) -> LayoutAttributes? {
-    guard cachedItems.count > 0 else {
-        return nil
-    }
-    guard indexPath.section < cachedItems.count else {
+    if indexPathIsOutOfBounds(indexPath, for: cachedItems) {
         return nil
     }
 
@@ -269,7 +270,6 @@
     let result = binarySearch.findElement(in: cachedItems[indexPath.section],
                                           less: compare,
                                           match: { indexPath == $0.indexPath })
-    print("Results : \(result.debugDescription)")
     return result
   }
 

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -253,7 +253,10 @@
   /// - Parameter indexPath: The index path of the item whose attributes are requested.
   /// - Returns: A layout attributes object containing the information to apply to the item’s cell.
   override open func layoutAttributesForItem(at indexPath: IndexPath) -> LayoutAttributes? {
-    guard cachedItems.count > 0, indexPath.section < cachedItems.count else {
+    guard cachedItems.count > 0 else {
+        return nil
+    }
+    guard indexPath.section < cachedItems.count else {
         return nil
     }
 

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -256,7 +256,6 @@
     guard cachedItems.count > 0, indexPath.section < cachedItems.count else {
         return nil
     }
-    //guard indexPath.section < cachedItems.count else { return nil }
 
     let compare: (LayoutAttributes) -> Bool
     #if os(macOS)

--- a/Sources/iOS+tvOS/Extensions/BlueprintLayout+iOS+tvOS.swift
+++ b/Sources/iOS+tvOS/Extensions/BlueprintLayout+iOS+tvOS.swift
@@ -2,7 +2,10 @@ import UIKit
 
 extension BlueprintLayout {
   open override func layoutAttributesForSupplementaryView(ofKind elementKind: String, at indexPath: IndexPath) -> LayoutAttributes? {
-    guard cachedAttributes.count > 0, indexPath.section < cachedAttributes.count else {
+    guard cachedAttributes.count > 0 else {
+        return nil
+    }
+    guard indexPath.section < cachedAttributes.count else {
         return nil
     }
 

--- a/Sources/iOS+tvOS/Extensions/BlueprintLayout+iOS+tvOS.swift
+++ b/Sources/iOS+tvOS/Extensions/BlueprintLayout+iOS+tvOS.swift
@@ -2,7 +2,7 @@ import UIKit
 
 extension BlueprintLayout {
   open override func layoutAttributesForSupplementaryView(ofKind elementKind: String, at indexPath: IndexPath) -> LayoutAttributes? {
-    guard cachedAttributes.count < 0, indexPath.section < cachedAttributes.count else {
+    guard cachedAttributes.count > 0, indexPath.section < cachedAttributes.count else {
         return nil
     }
 

--- a/Sources/iOS+tvOS/Extensions/BlueprintLayout+iOS+tvOS.swift
+++ b/Sources/iOS+tvOS/Extensions/BlueprintLayout+iOS+tvOS.swift
@@ -2,10 +2,7 @@ import UIKit
 
 extension BlueprintLayout {
   open override func layoutAttributesForSupplementaryView(ofKind elementKind: String, at indexPath: IndexPath) -> LayoutAttributes? {
-    guard cachedAttributes.count > 0 else {
-        return nil
-    }
-    guard indexPath.section < cachedAttributes.count else {
+    if indexPathIsOutOfBounds(indexPath, for: cachedAttributes) {
         return nil
     }
 

--- a/Sources/iOS+tvOS/Extensions/BlueprintLayout+iOS+tvOS.swift
+++ b/Sources/iOS+tvOS/Extensions/BlueprintLayout+iOS+tvOS.swift
@@ -2,6 +2,10 @@ import UIKit
 
 extension BlueprintLayout {
   open override func layoutAttributesForSupplementaryView(ofKind elementKind: String, at indexPath: IndexPath) -> LayoutAttributes? {
+    guard cachedAttributes.count < 0, indexPath.section < cachedAttributes.count else {
+        return nil
+    }
+
     let sectionAttributes = cachedAttributes[indexPath.section]
     var layoutAttributesResult: LayoutAttributes? = nil
 

--- a/Sources/macOS/Extensions/BlueprintLayout+macOS.swift
+++ b/Sources/macOS/Extensions/BlueprintLayout+macOS.swift
@@ -2,10 +2,7 @@ import Cocoa
 
 extension BlueprintLayout {
   open override func layoutAttributesForSupplementaryView(ofKind elementKind: NSCollectionView.SupplementaryElementKind, at indexPath: IndexPath) -> LayoutAttributes? {
-    guard cachedAttributes.count > 0 else {
-        return nil
-    }
-    guard indexPath.section < cachedAttributes.count else {
+    if indexPathIsOutOfBounds(indexPath, for: cachedAttributes) {
         return nil
     }
 

--- a/Sources/macOS/Extensions/BlueprintLayout+macOS.swift
+++ b/Sources/macOS/Extensions/BlueprintLayout+macOS.swift
@@ -2,7 +2,10 @@ import Cocoa
 
 extension BlueprintLayout {
   open override func layoutAttributesForSupplementaryView(ofKind elementKind: NSCollectionView.SupplementaryElementKind, at indexPath: IndexPath) -> LayoutAttributes? {
-    guard cachedAttributes.count > 0, indexPath.section < cachedAttributes.count else {
+    guard cachedAttributes.count > 0 else {
+        return nil
+    }
+    guard indexPath.section < cachedAttributes.count else {
         return nil
     }
 

--- a/Sources/macOS/Extensions/BlueprintLayout+macOS.swift
+++ b/Sources/macOS/Extensions/BlueprintLayout+macOS.swift
@@ -2,6 +2,10 @@ import Cocoa
 
 extension BlueprintLayout {
   open override func layoutAttributesForSupplementaryView(ofKind elementKind: NSCollectionView.SupplementaryElementKind, at indexPath: IndexPath) -> LayoutAttributes? {
+    guard cachedAttributes.count > 0, indexPath.section < cachedAttributes.count else {
+        return nil
+    }
+
     let sectionAttributes = cachedAttributes[indexPath.section]
     var layoutAttributesResult: LayoutAttributes? = nil
 


### PR DESCRIPTION
I have had to add a check to ensure that they are cachedItems/attributes before checking the indexPath.section < cachedItems/attributes.count.

I have observed a case where the indexPath get's invalidated, this can be seen when you delete a section with a supplementary view within batch updates. However I am not sure at what point this becomes an empty index, it shouldn't occur! (So it may be possible that this will still fail) I have included the same check throughout just to air on the side of caution but I have only seen this happen for the supplementary views at this time.

![screenshot 2018-12-06 at 10 53 22](https://user-images.githubusercontent.com/12499390/49583533-72970580-f950-11e8-91e0-8efaf8112249.png)