### PR TITLE
Fix missing offset in #47

### DIFF
--- a/Sources/Shared/Core/VerticalBlueprintLayout.swift
+++ b/Sources/Shared/Core/VerticalBlueprintLayout.swift
@@ -106,7 +106,7 @@
             itemsPerRow > 1,
             item > Int(itemsPerRow) - 1,
             Int(itemsPerRow) - 1 < layoutAttributes[section].count {
-            let previousXOffset = item - Int(itemsPerRow)
+            let previousXOffset = item - Int(itemsPerRow - 1)
             let lookupAttribute = layoutAttributes[section][previousXOffset]
             maxY = lookupAttribute.frame.maxY
             minY = lookupAttribute.frame.maxY + minimumLineSpacing


### PR DESCRIPTION
Fixes #47 

Required or the wrong item is looked-up from the layoutAttributes.

@zenangst - Have left the variable for sectionMaxY for the time been as I believe this will be required to resolve the issue with the incorrect position of the footer when multiple columns are used.