### PR TITLE
Use sectionMaxY instead of nextY

### DIFF
--- a/Sources/Shared/Core/VerticalBlueprintLayout.swift
+++ b/Sources/Shared/Core/VerticalBlueprintLayout.swift
@@ -172,7 +172,7 @@
           }
         }
 
-        contentSize.height = previousItem.frame.maxY - headerReferenceSize.height + sectionInset.bottom
+        contentSize.height = sectionMaxY - headerReferenceSize.height + sectionInset.bottom
       }
 
       previousItem = nil

--- a/Sources/Shared/Core/VerticalBlueprintLayout.swift
+++ b/Sources/Shared/Core/VerticalBlueprintLayout.swift
@@ -140,7 +140,7 @@
           let layoutAttribute = createSupplementaryLayoutAttribute(
             ofKind: .footer,
             indexPath: sectionIndexPath,
-            atY: nextY + sectionInset.bottom
+            atY: sectionMaxY + sectionInset.bottom
           )
           layoutAttributes[section].append(layoutAttribute)
           nextY = layoutAttribute.frame.maxY


### PR DESCRIPTION
Use the sectionMaxY variable instead of nextY to fix rendering issues when using cells with dynamic height.