### PR TITLE
Add padding to BinarySearch.findElements

### DIFF
--- a/Blueprints.podspec
+++ b/Blueprints.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Blueprints"
   s.summary          = "A collection of flow layouts that is meant to make your life easier."
-  s.version          = "0.8.5"
+  s.version          = "0.8.6"
   s.homepage         = "https://github.com/zenangst/Blueprints"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/Shared/Core/BinarySearch.swift
+++ b/Sources/Shared/Core/BinarySearch.swift
@@ -35,21 +35,38 @@ public class BinarySearch {
   }
 
   public func findElements(in collection: [LayoutAttributes],
-                              less: (LayoutAttributes) -> Bool,
-                              match: (LayoutAttributes) -> Bool) -> [LayoutAttributes]? {
+                           padding: Int = 0,
+                           less: (LayoutAttributes) -> Bool,
+                           match: (LayoutAttributes) -> Bool) -> [LayoutAttributes]? {
     guard let firstMatchIndex = binarySearch(collection, less: less, match: match) else {
       return nil
     }
 
     var results = [LayoutAttributes]()
+    var counter = padding
 
     for element in collection[..<firstMatchIndex].reversed() {
-      guard match(element) else { break }
+      if !match(element) {
+        if padding > 1 {
+          counter -= 1
+          if counter == 0 { break }
+        } else {
+          break
+        }
+      }
       results.append(element)
     }
 
+    counter = padding
     for element in collection[firstMatchIndex...] {
-      guard match(element) else { break }
+      if !match(element) {
+        if padding > 1 {
+          counter -= 1
+          if counter == 0 { break }
+        } else {
+          break
+        }
+      }
       results.append(element)
     }
 

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -287,9 +287,10 @@
   /// - Returns: An array of layout attribute objects containing the layout information for the enclosed items and views.
   override open func layoutAttributesForElements(in rect: CGRect) -> LayoutAttributesForElements {
     let closure: (LayoutAttributes) -> Bool = scrollDirection == .horizontal
-      ? { rect.maxX > $0.frame.minX }
-      : { rect.maxY > $0.frame.minY }
+      ? { rect.maxX >= $0.frame.minX }
+      : { rect.maxY >= $0.frame.minY }
     let result = binarySearch.findElements(in: allCachedAttributes,
+                                           padding: Int(itemsPerRow ?? 0),
                                            less: { closure($0) },
                                            match: { $0.frame.intersects(rect) })
     return result ?? allCachedAttributes.filter { $0.frame.intersects(rect) }


### PR DESCRIPTION
When using multiple items per row with dynamic height, the binary search can cause UI glitches where certain items simply disappear after a certain content offset. To fix this issue, the `findElements` method can now pad the results that it finds. The itemsPerRow is used for padding. What padding means in this context is the number of extra items that should be allowed to exist even if they don't meet the search criteria. That way we can capture all views that are on the same row even if they have different y,x coordinates. In a real-world scenario, the number of padded items should never exceed four or five, tops.