### PR TITLE
Improve mosaic blueprint initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ let collectionView = UICollectionView(frame: .zero,
 ### Mosaic layout
 ```swift
 let mosaicLayout = VerticalMosaicBlueprintLayout(
-  itemSize: CGSize.init(width: 50, height: 400),
+  patternHeight: 400,
   minimumInteritemSpacing: 2,
   minimumLineSpacing: 2,
   sectionInset: EdgeInsets(top: 2, left: 2, bottom: 2, right: 2),

--- a/Sources/Shared/Mosaic/VerticalMosaicBlueprintLayout.swift
+++ b/Sources/Shared/Mosaic/VerticalMosaicBlueprintLayout.swift
@@ -8,8 +8,7 @@
   private let controller: MosaicBlueprintPatternController
 
   @objc public required init(
-    itemSize: CGSize = CGSize(width: 50, height: 50),
-    estimatedItemSize: CGSize = .zero,
+    patternHeight: CGFloat = 50,
     minimumInteritemSpacing: CGFloat = 10,
     minimumLineSpacing: CGFloat = 10,
     sectionInset: EdgeInsets = EdgeInsets(top: 0, left: 0, bottom: 0, right: 0),
@@ -19,8 +18,8 @@
     self.controller = MosaicBlueprintPatternController(patterns: patterns)
     super.init(
       itemsPerRow: 0.0,
-      itemSize: itemSize,
-      estimatedItemSize: estimatedItemSize,
+      itemSize: .init(width: 50, height: patternHeight),
+      estimatedItemSize: .zero,
       minimumInteritemSpacing: minimumInteritemSpacing,
       minimumLineSpacing: minimumLineSpacing,
       sectionInset: sectionInset,

--- a/Tests/iOS+tvOS/iOStvOSObjectiveCSupportTests.m
+++ b/Tests/iOS+tvOS/iOStvOSObjectiveCSupportTests.m
@@ -54,13 +54,12 @@
 
 - (void)testMosaicBluePrintLayout {
 
-  VerticalMosaicBlueprintLayout *layout = [[VerticalMosaicBlueprintLayout alloc] initWithItemSize:CGSizeMake(50, 50)
-                                                                                estimatedItemSize:CGSizeZero
-                                                                          minimumInteritemSpacing:20.0
-                                                                               minimumLineSpacing:50.0
-                                                                                     sectionInset:UIEdgeInsetsMake(20, 20, 20, 20)
-                                                                                         animator:nil
-                                                                                         patterns:@[]];
+  VerticalMosaicBlueprintLayout *layout = [[VerticalMosaicBlueprintLayout alloc] initWithPatternHeight:50
+                                                                               minimumInteritemSpacing:20.0
+                                                                                    minimumLineSpacing:50.0
+                                                                                          sectionInset:UIEdgeInsetsMake(20, 20, 20, 20)
+                                                                                              animator:nil
+                                                                                              patterns:@[]];
   XCTAssertEqual(layout.minimumInteritemSpacing, 20);
   XCTAssertEqual(layout.minimumLineSpacing, 50);
 }


### PR DESCRIPTION
This PR changes the initializer of the Mosaic layout to only include a pattern height instead of an item size. The width of the item is never used so this change is motivated by removing the confusion that it might be used. The new label is called `patternHeight`.

Reference: https://github.com/zenangst/Blueprints/issues/43