### PR TITLE
Build example on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ script:
   - set -o pipefail && xcodebuild -project Blueprints.xcodeproj -scheme "Blueprints-iOS" -sdk iphonesimulator -destination name="iPhone 8" -enableCodeCoverage YES test | xcpretty
   - set -o pipefail && xcodebuild -project Blueprints.xcodeproj -scheme "Blueprints-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV,OS=11.4' clean build | xcpretty
   - set -o pipefail && xcodebuild -project Blueprints.xcodeproj -scheme "Blueprints-tvOS" -destination 'platform=tvOS Simulator,name=Apple TV,OS=11.4' -enableCodeCoverage YES test | xcpretty
+  - set -o pipefail && xcodebuild -project Blueprints.xcodeproj -scheme "Example-iOS" -sdk iphonesimulator -destination name="iPhone 8" clean build | xcpretty
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Example-iOS/Scenes/LayoutExampleSceneViewController+VerticalMosaicBlueprintLayout.swift
+++ b/Example-iOS/Scenes/LayoutExampleSceneViewController+VerticalMosaicBlueprintLayout.swift
@@ -4,35 +4,34 @@ import UIKit
 extension LayoutExampleSceneViewController {
 
     func configureMosaicLayout() {
-        let mosaicBlueprintLayout = VerticalMosaicBlueprintLayout(
-            itemSize: CGSize.init(width: 50,
-                                  height: 400),
-            minimumInteritemSpacing: minimumInteritemSpacing,
-            minimumLineSpacing: minimumLineSpacing,
-            sectionInset: sectionInsets,
-            patterns: [
-                MosaicPattern(alignment: .left,
-                              direction: .vertical,
-                              amount: 2,
-                              multiplier: 0.6),
-                MosaicPattern(alignment: .left,
-                              direction: .horizontal,
-                              amount: 2,
-                              multiplier: 0.33),
-                MosaicPattern(alignment: .left,
-                              direction: .vertical,
-                              amount: 1,
-                              multiplier: 0.5),
-                MosaicPattern(alignment: .left,
-                              direction: .vertical,
-                              amount: 1,
-                              multiplier: 0.5)
-            ])
-
-        UIView.animate(withDuration: 0.5) { [weak self] in
-            self?.layoutExampleCollectionView.collectionViewLayout = mosaicBlueprintLayout
-            self?.view.setNeedsLayout()
-            self?.view.layoutIfNeeded()
-        }
-    }
+      let mosaicBlueprintLayout = VerticalMosaicBlueprintLayout(
+        patternHeight: 400,
+        minimumInteritemSpacing: minimumInteritemSpacing,
+        minimumLineSpacing: minimumLineSpacing,
+        sectionInset: sectionInsets,
+        patterns: [
+          MosaicPattern(alignment: .left,
+                        direction: .vertical,
+                        amount: 2,
+                        multiplier: 0.6),
+          MosaicPattern(alignment: .left,
+                        direction: .horizontal,
+                        amount: 2,
+                        multiplier: 0.33),
+          MosaicPattern(alignment: .left,
+                        direction: .vertical,
+                        amount: 1,
+                        multiplier: 0.5),
+          MosaicPattern(alignment: .left,
+                        direction: .vertical,
+                        amount: 1,
+                        multiplier: 0.5)
+        ])
+      
+      UIView.animate(withDuration: 0.5) { [weak self] in
+        self?.layoutExampleCollectionView.collectionViewLayout = mosaicBlueprintLayout
+        self?.view.setNeedsLayout()
+        self?.view.layoutIfNeeded()
+      }
+  }
 }


### PR DESCRIPTION
To avoid breaking the example project when changing the public API (or other things), Travis will now build the example project just to see that everything compiles.

It also fixes the example project that was broken (because I forgot to update it) :trollface: 