### PR TITLE
Return the frame instead of the documentVisibleRect

### DIFF
--- a/Sources/macOS/Extensions/NSCollectionView+Extensions.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+Extensions.swift
@@ -14,7 +14,7 @@ public extension CollectionView {
   }
 
   var documentRect: CGRect {
-    return enclosingScrollView?.documentVisibleRect ?? .zero
+    return enclosingScrollView?.frame ?? .zero
   }
 
   convenience public init(frame: CGRect, collectionViewLayout: CollectionViewFlowLayout) {


### PR DESCRIPTION
This resolves the issue when the incorrect threshold is used to calculate the available space when laying out the cells on OSX. #68 