### PR TITLE
Compare contentSize.width in shouldInvalidateLayout

### DIFF
--- a/Sources/Shared/Core/VerticalBlueprintLayout.swift
+++ b/Sources/Shared/Core/VerticalBlueprintLayout.swift
@@ -256,6 +256,12 @@
   }
 
   override open func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
-    return stickyFooters || stickyHeaders
+    var shouldInvalidate = stickyFooters || stickyHeaders
+
+    if contentSize.width != newBounds.size.width {
+      shouldInvalidate = true
+    }
+
+    return shouldInvalidate
   }
 }


### PR DESCRIPTION
Improves handling resizing of windows. If the content size width is different than the new bounds, then the layout will invalidate.