### PR TITLE
OSX - Use collection view frame width instead of the enclosing scroll view

### DIFF
--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -111,12 +111,7 @@
   /// - Returns: The desired size of the item at the index path.
   func resolveSizeForItem(at indexPath: IndexPath) -> CGSize {
     if let collectionView = collectionView, let itemsPerRow = itemsPerRow, itemsPerRow > 0 {
-      let containerWidth: CGFloat
-      #if os(macOS)
-        containerWidth = collectionView.enclosingScrollView?.frame.width ?? collectionView.frame.size.width
-      #else
-        containerWidth = collectionView.frame.size.width
-      #endif
+      let containerWidth = collectionView.frame.size.width
 
       let height = resolveCollectionView({ collectionView -> CGSize? in
         return (collectionView.delegate as? CollectionViewFlowLayoutDelegate)?.collectionView?(collectionView,


### PR DESCRIPTION
#71 This is to make sure that the scrollbar is not overlapping the cells when certain styles are used based on the users preferences.

![screenshot 2019-01-17 at 14 05 13](https://user-images.githubusercontent.com/12499390/51323747-ebfe3980-1a60-11e9-9173-0d8c4b811823.png)
