### PR TITLE
Update footerY calculations for OSX

### DIFF
--- a/Sources/Shared/Core/VerticalBlueprintLayout.swift
+++ b/Sources/Shared/Core/VerticalBlueprintLayout.swift
@@ -228,8 +228,14 @@
           }
 
           if stickyFooters {
+            let heightThreshold: CGFloat
+            #if os(macOS)
+              heightThreshold = collectionView.enclosingScrollView?.bounds.height ?? collectionView.bounds.height
+            #else
+              heightThreshold = collectionView.bounds.height
+            #endif
             let footerY = min(
-              max(collectionView.contentOffset.y + collectionView.bounds.height - footerReferenceSize.height,
+              max(collectionView.contentOffset.y + heightThreshold - footerReferenceSize.height,
                   firstItem.frame.minY),
               sectionMaxY + sectionInset.bottom)
 


### PR DESCRIPTION
Fixes #73 - When the collection view has an enclosingScrollView this should be used to calculate the height of which the items should be pinned.