### PR TITLE
Adding headerReferenceSize to example project.

### DIFF
--- a/Example-iOS/Scenes/LayoutExampleSceneViewController+VerticalMosaicBlueprintLayout.swift
+++ b/Example-iOS/Scenes/LayoutExampleSceneViewController+VerticalMosaicBlueprintLayout.swift
@@ -27,6 +27,9 @@ extension LayoutExampleSceneViewController {
                         amount: 1,
                         multiplier: 0.5)
         ])
+        
+      let titleCollectionReusableViewSize = CGSize(width: view.bounds.width, height: 61)
+      mosaicBlueprintLayout.headerReferenceSize = titleCollectionReusableViewSize
       
       UIView.animate(withDuration: 0.5) { [weak self] in
         self?.layoutExampleCollectionView.collectionViewLayout = mosaicBlueprintLayout


### PR DESCRIPTION
Shows the basic implementation for headers in the mosaic layout that have been added in #75 