### PR TITLE
Fix document rect so that the scroll bar is correctly positioned in OSX

### DIFF
--- a/Sources/macOS/Extensions/NSCollectionView+Extensions.swift
+++ b/Sources/macOS/Extensions/NSCollectionView+Extensions.swift
@@ -14,7 +14,13 @@ public extension CollectionView {
   }
 
   var documentRect: CGRect {
-    return enclosingScrollView?.frame ?? .zero
+    guard let enclosingScrollView = enclosingScrollView else {
+      return .zero
+    }
+    if frame.width > enclosingScrollView.frame.width {
+      return enclosingScrollView.frame
+    }
+    return frame
   }
 
   convenience public init(frame: CGRect, collectionViewLayout: CollectionViewFlowLayout) {


### PR DESCRIPTION
Fixes #79 when the scrollbar is always visible it overlaps the cells, this will ensure that this doesn't happen.