### PR TITLE
Fix content size issue on macOS

### DIFF
--- a/Blueprints.xcodeproj/project.pbxproj
+++ b/Blueprints.xcodeproj/project.pbxproj
@@ -1187,6 +1187,11 @@
 					836DB27921ECBE77003D38B1 = {
 						CreatedOnToolsVersion = 10.1;
 						ProvisioningStyle = Automatic;
+						SystemCapabilities = {
+							com.apple.Sandbox = {
+								enabled = 0;
+							};
+						};
 					};
 					D284B0FB1F79038B00D94AF3 = {
 						CreatedOnToolsVersion = 9.0;
@@ -1653,7 +1658,6 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_ENTITLEMENTS = "Example-OSX/Example_OSX.entitlements";
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -1681,7 +1685,6 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_ENTITLEMENTS = "Example-OSX/Example_OSX.entitlements";
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;

--- a/Example-OSX/AppDelegate.swift
+++ b/Example-OSX/AppDelegate.swift
@@ -6,7 +6,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var window: NSWindow?
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
-      Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/macOSInjection10.bundle")?.load()
+        Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/macOSInjection10.bundle")?.load()
 
         guard let mainScreen = NSScreen.main ?? NSScreen.screens.first else {
             fatalError("Expected a display.")

--- a/Example-OSX/AppDelegate.swift
+++ b/Example-OSX/AppDelegate.swift
@@ -6,6 +6,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var window: NSWindow?
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
+      Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/macOSInjection10.bundle")?.load()
+
         guard let mainScreen = NSScreen.main ?? NSScreen.screens.first else {
             fatalError("Expected a display.")
         }

--- a/Example-OSX/Example_OSX.entitlements
+++ b/Example-OSX/Example_OSX.entitlements
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-    <key>com.apple.security.app-sandbox</key>
-    <true/>
-    <key>com.apple.security.files.user-selected.read-only</key>
-    <true/>
-</dict>
+<dict/>
 </plist>

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -225,7 +225,7 @@
   /// - Parameter attributes: The attributes that were created in the collection view layout.
   func createCache(with attributes: [[LayoutAttributes]]) {
     #if os(macOS)
-      macOSWorkaround()
+      macOSWorkaroundCreateCache()
     #endif
 
     for value in attributes {

--- a/Sources/macOS/Extensions/BlueprintLayout+macOS.swift
+++ b/Sources/macOS/Extensions/BlueprintLayout+macOS.swift
@@ -24,6 +24,7 @@ extension BlueprintLayout {
   open override func finalizeLayoutTransition() {
     super.finalizeLayoutTransition()
     collectionView?.enclosingScrollView?.layout()
+    macOSWorkaroundSetNewContentSize()
   }
 
   /// On macOS, collection views that don't have an initial size won't
@@ -34,7 +35,7 @@ extension BlueprintLayout {
   /// properly. If a hidden collection view gets a new content size
   /// it will restore the alpha value to 1.0, but only if the alpha value
   /// is equal to the workaround value.
-  func macOSWorkaround() {
+  func macOSWorkaroundCreateCache() {
     let alphaValue: CGFloat = 0.0001
     if contentSize.height == 0 && collectionView?.alphaValue != 0.0 {
       contentSize.height = 0.5
@@ -43,6 +44,28 @@ extension BlueprintLayout {
       collectionView?.alphaValue = 1.0
     }
     collectionView?.frame.size.height = contentSize.height
+  }
+
+  /// When transitioning between layouts macOS does not set the
+  /// proper size to the document view of the scroll view.
+  /// To work around this, the collection views window will
+  /// temporarily be resized and then restored. This will
+  /// trigger the document view getting the new size.
+  func macOSWorkaroundSetNewContentSize() {
+    if let window = collectionView?.window {
+      CATransaction.begin()
+      CATransaction.setDisableActions(true)
+      CATransaction.setAnimationDuration(0.0)
+      let originalFrame = window.frame
+      var frame = originalFrame
+      frame.origin.y = frame.origin.y - 0.025
+      frame.size.height = frame.size.height + 0.025
+      window.setFrame(frame, display: false)
+      CATransaction.commit()
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.045) {
+        window.setFrame(originalFrame, display: false)
+      }
+    }
   }
 
   func configureHeaderFooterWidth(_ view: NSView) {


### PR DESCRIPTION
This adds a "horrible" hack to get the content size to update on macOS when transitioning between layouts. It will temporarily resize the window to make sure that the scroll view's document view gets a new size.

Fixes #87

- Enables `InjectionIII` for the macOS demo