### PR TITLE
Check the current frame against the existing section max y

### DIFF
--- a/Sources/Shared/Core/VerticalBlueprintLayout.swift
+++ b/Sources/Shared/Core/VerticalBlueprintLayout.swift
@@ -176,7 +176,7 @@
             layoutAttribute.frame.origin.y = maxY + minimumLineSpacing
           }
 
-          sectionMaxY = max(previousItem.frame.maxY, layoutAttribute.frame.maxY)
+          sectionMaxY = max(sectionMaxY, layoutAttribute.frame.maxY)
         } else {
           firstItem = layoutAttribute
           layoutAttribute.frame.origin.x = sectionInset.left


### PR DESCRIPTION
as the previous item may not be the current max, depending on the dynamic heights and number of rows.