### PR TITLE
Fix setting content size on empty layouts on macOS

### DIFF
--- a/Blueprints.podspec
+++ b/Blueprints.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Blueprints"
   s.summary          = "A collection of flow layouts that is meant to make your life easier."
-  s.version          = "0.10.3"
+  s.version          = "0.10.4"
   s.homepage         = "https://github.com/zenangst/Blueprints"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -243,7 +243,7 @@
   /// - Parameter attributes: The attributes that were created in the collection view layout.
   func createCache(with attributes: [[LayoutAttributes]]) {
     #if os(macOS)
-      macOSWorkaroundCreateCache()
+      macOSWorkaroundCreateCache(with: attributes)
     #endif
 
     for value in attributes {

--- a/Sources/macOS/Extensions/BlueprintLayout+macOS.swift
+++ b/Sources/macOS/Extensions/BlueprintLayout+macOS.swift
@@ -36,7 +36,7 @@ extension BlueprintLayout {
   /// properly. If a hidden collection view gets a new content size
   /// it will restore the alpha value to 1.0, but only if the alpha value
   /// is equal to the workaround value.
-  func macOSWorkaroundCreateCache() {
+  func macOSWorkaroundCreateCache(with attributes: [[LayoutAttributes]]) {
     let alphaValue: CGFloat = 0.0001
     if contentSize.height == 0 && collectionView?.alphaValue != 0.0 {
       contentSize.height = super.collectionViewContentSize.height
@@ -44,7 +44,15 @@ extension BlueprintLayout {
     } else if collectionView?.alphaValue == alphaValue {
       collectionView?.alphaValue = 1.0
     }
-    collectionView?.frame.size.height = contentSize.height
+
+    // Check that the layout has attributes, otherwise set the content size height
+    // to zero to indicate that it is truly empty.
+    if !attributes.isEmpty {
+      collectionView?.frame.size.height = contentSize.height
+    } else {
+      contentSize.height = 0
+      collectionView?.frame.size.height = 0
+    }
   }
 
   /// When transitioning between layouts macOS does not set the


### PR DESCRIPTION
- 💻 Empty collection view layouts now receive a content size height of zero on macOS.