### PR TITLE
Bug/rogue calls to prepare without invalidating the context

### DIFF
--- a/Blueprints.podspec
+++ b/Blueprints.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Blueprints"
   s.summary          = "A collection of flow layouts that is meant to make your life easier."
-  s.version          = "0.11.0"
+  s.version          = "0.11.1"
   s.homepage         = "https://github.com/zenangst/Blueprints"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -26,6 +26,7 @@
   public var cachedItemAttributesBySection = [[LayoutAttributes]]()
   public var allCachedAttributes = [LayoutAttributes]()
   var binarySearch = BinarySearch()
+  var prepareAllowed = true
 
   /// The content size of the layout, should be set using the `prepare` method of any subclass.
   public var contentSize: CGSize = .zero
@@ -332,8 +333,7 @@
   }
 
   open override func invalidateLayout(with context: LayoutInvalidationContext) {
-    cachedItemAttributes = []
-    cachedSupplementaryAttributes = []
+    prepareAllowed = true
 
     if context.invalidateEverything == false {
       positionHeadersAndFooters(with: context)

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -332,6 +332,9 @@
   }
 
   open override func invalidateLayout(with context: LayoutInvalidationContext) {
+    cachedItemAttributes = []
+    cachedSupplementaryAttributes = []
+
     if context.invalidateEverything == false {
       positionHeadersAndFooters(with: context)
 

--- a/Sources/Shared/Core/HorizontalBlueprintLayout.swift
+++ b/Sources/Shared/Core/HorizontalBlueprintLayout.swift
@@ -119,10 +119,10 @@
   }
 
   override open func prepare() {
-    guard cachedItemAttributes.isEmpty,
-        cachedSupplementaryAttributes.isEmpty else {
-            return
+    guard prepareAllowed else {
+        return
     }
+    prepareAllowed = false
 
     super.prepare()
 

--- a/Sources/Shared/Core/HorizontalBlueprintLayout.swift
+++ b/Sources/Shared/Core/HorizontalBlueprintLayout.swift
@@ -119,7 +119,13 @@
   }
 
   override open func prepare() {
+    guard cachedItemAttributes.isEmpty,
+        cachedSupplementaryAttributes.isEmpty else {
+            return
+    }
+
     super.prepare()
+
     var layoutAttributes = [[LayoutAttributes]]()
     var contentSize: CGSize = .zero
     var nextX: CGFloat = 0

--- a/Sources/Shared/Core/VerticalBlueprintLayout.swift
+++ b/Sources/Shared/Core/VerticalBlueprintLayout.swift
@@ -104,6 +104,11 @@
   }
 
   override open func prepare() {
+    guard cachedItemAttributes.isEmpty,
+        cachedSupplementaryAttributes.isEmpty else {
+            return
+    }
+
     super.prepare()
 
     var layoutAttributes = [[LayoutAttributes]]()

--- a/Sources/Shared/Core/VerticalBlueprintLayout.swift
+++ b/Sources/Shared/Core/VerticalBlueprintLayout.swift
@@ -104,10 +104,10 @@
   }
 
   override open func prepare() {
-    guard cachedItemAttributes.isEmpty,
-        cachedSupplementaryAttributes.isEmpty else {
-            return
+    guard prepareAllowed else {
+        return
     }
+    prepareAllowed = false
 
     super.prepare()
 

--- a/Sources/Shared/Mosaic/VerticalMosaicBlueprintLayout.swift
+++ b/Sources/Shared/Mosaic/VerticalMosaicBlueprintLayout.swift
@@ -37,10 +37,10 @@
   }
 
   override public func prepare() {
-    guard cachedItemAttributes.isEmpty,
-        cachedSupplementaryAttributes.isEmpty else {
-            return
+    guard prepareAllowed else {
+        return
     }
+    prepareAllowed = false
 
     super.prepare()
 

--- a/Sources/Shared/Mosaic/VerticalMosaicBlueprintLayout.swift
+++ b/Sources/Shared/Mosaic/VerticalMosaicBlueprintLayout.swift
@@ -37,7 +37,13 @@
   }
 
   override public func prepare() {
+    guard cachedItemAttributes.isEmpty,
+        cachedSupplementaryAttributes.isEmpty else {
+            return
+    }
+
     super.prepare()
+
     var layoutAttributes = [[LayoutAttributes]]()
     var threshold: CGFloat = 0.0
 


### PR DESCRIPTION
Fixes #107 - I don't think we should be having to do this, but occasionally prepare is called without the context been invalidated causing additional calls to things like sizeForItemAt.

This would normally go unnoticed, but I have been playing around with resizable child containers that have collection views with the custom layouts.

Occasionally the rogue calls would add more items than needed into the dynamic height cache I had held causing some cells to have the incorrect size.