### PR TITLE
Fix header & footer x origin when reaching the end

### DIFF
--- a/Blueprints.podspec
+++ b/Blueprints.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Blueprints"
   s.summary          = "A collection of flow layouts that is meant to make your life easier."
-  s.version          = "0.11.2"
+  s.version          = "0.11.3"
   s.homepage         = "https://github.com/zenangst/Blueprints"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -398,13 +398,6 @@
           }
         case .horizontal:
           header.frame.origin.x = min(max(collectionView.contentOffset.x, header.min), header.max - header.frame.size.width)
-
-          // Adjust the X-origin if the content offset exceeds the width of the content size.
-          // This should only happen if you use section insets and have scrolled to the very end
-          // of the collection view.
-          if contentSize.width > collectionView.frame.size.width && collectionView.contentOffset.x > contentSize.width - collectionView.frame.size.width {
-            header.frame.origin.x = collectionView.contentOffset.x + sectionInset.left + sectionInset.right
-          }
         @unknown default:
           fatalError("Case not implemented in current implementation")
         }
@@ -429,13 +422,6 @@
           footer.frame.origin.x = min(max(collectionView.contentOffset.x, footer.min), footer.max - footer.frame.size.width)
         @unknown default:
           fatalError("Case not implemented in current implementation")
-        }
-
-        // Adjust the X-origin if the content offset exceeds the width of the content size.
-        // This should only happen if you use section insets and have scrolled to the very end
-        // of the collection view.
-        if contentSize.width > collectionView.frame.size.width && collectionView.contentOffset.x > contentSize.width - collectionView.frame.size.width {
-          footer.frame.origin.x = collectionView.contentOffset.x + sectionInset.left + sectionInset.right
         }
 
         if let invalidationContext = context as? BlueprintInvalidationContext {


### PR DESCRIPTION
Removes the previous fixes that was suppose to align the headers and footers
correctly when reaching the end of a collection view. It appears that the
previous fix was faulty and is now removed.