### PR TITLE
Implement delegate methods for header/footer reference size

### DIFF
--- a/Example-OSX/AppDelegate.swift
+++ b/Example-OSX/AppDelegate.swift
@@ -6,7 +6,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var window: NSWindow?
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
-        Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/macOSInjection10.bundle")?.load()
+        Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/macOSInjection.bundle")?.load()
 
         guard let mainScreen = NSScreen.main ?? NSScreen.screens.first else {
             fatalError("Expected a display.")

--- a/Example-iOS/AppDelegate.swift
+++ b/Example-iOS/AppDelegate.swift
@@ -9,7 +9,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         #if DEBUG
         // Load InjectionIII bundle
         // https://itunes.apple.com/us/app/injectioniii/id1380446739?mt=12
-        Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/iOSInjection10.bundle")?.load()
+        Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/iOSInjection.bundle")?.load()
         #endif
 
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -208,39 +208,6 @@
     }
   }
 
-  /// Create supplementary layout attributes.
-  ///
-  /// - Parameters:
-  ///   - kind: The supplementary kind, either header or footer.
-  ///   - indexPath: The section index path for the supplementary view.
-  ///   - x: The x coordinate of the header layout attributes.
-  ///   - y: The y coordinate of the header layout attributes.
-  /// - Returns: A `LayoutAttributes` object of supplementary kind.
-  func createSupplementaryLayoutAttribute(ofKind kind: BlueprintSupplementaryKind,
-                                          indexPath: IndexPath,
-                                          atX x: CGFloat = 0,
-                                          atY y: CGFloat = 0) -> SupplementaryLayoutAttributes {
-    let layoutAttribute = SupplementaryLayoutAttributes(
-      forSupplementaryViewOfKind: kind.collectionViewSupplementaryType,
-      with: indexPath
-    )
-
-    switch kind {
-    case .header:
-      layoutAttribute.size.width = collectionView?.documentRect.width ?? headerReferenceSize.width
-      layoutAttribute.size.height = headerReferenceSize.height
-    case .footer:
-      layoutAttribute.size.width = collectionView?.documentRect.width ?? footerReferenceSize.width
-      layoutAttribute.size.height = footerReferenceSize.height
-    }
-
-    layoutAttribute.zIndex = indexPath.section
-    layoutAttribute.frame.origin.x = x
-    layoutAttribute.frame.origin.y = y
-
-    return layoutAttribute
-  }
-
   /// Resolve collection collection view from layout and return
   /// property or default value if collection view cannot be resolved.
   ///

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -156,6 +156,58 @@
     }
   }
 
+  /// Resolve the size of SupplementaryView at index path.
+  /// If the collection view's delegate conforms to `(UI/NS)CollectionViewDelegateFlowLayout`, it will
+  /// query the delegate for the size of the SupplementaryView.
+  /// It defaults to using the `headerReferenceSize` or `footerReferenceSize` property on collection view flow layout.
+  ///
+  /// - Parameter indexPath: The index path of the supplementaryView.
+  /// - Returns: The desired size of the item at the index path.
+  func resolveSizeForSupplementaryView(ofKind kind: BlueprintSupplementaryKind, at indexPath: IndexPath) -> CGSize {
+    switch kind {
+    case .header:
+      let height = resolveCollectionView({ collectionView -> CGSize? in
+        return (collectionView.delegate as? CollectionViewFlowLayoutDelegate)?.collectionView?(collectionView,
+                                                                                               layout: self,
+                                                                                               referenceSizeForHeaderInSection: indexPath.section)
+      }, defaultValue: headerReferenceSize).height
+
+      let width: CGFloat
+      if headerReferenceSize.width > 0 {
+        width = headerReferenceSize.width
+      } else {
+        width = collectionView?.documentRect.width ?? headerReferenceSize.width
+      }
+
+      let size = CGSize(
+        width: width,
+        height: height
+      )
+
+      return size
+    case .footer:
+      let height = resolveCollectionView({ collectionView -> CGSize? in
+        return (collectionView.delegate as? CollectionViewFlowLayoutDelegate)?.collectionView?(collectionView,
+                                                                                               layout: self,
+                                                                                               referenceSizeForFooterInSection: indexPath.section)
+      }, defaultValue: headerReferenceSize).height
+
+      let width: CGFloat
+      if footerReferenceSize.width > 0 {
+        width = footerReferenceSize.width
+      } else {
+        width = collectionView?.documentRect.width ?? footerReferenceSize.width
+      }
+
+      let size = CGSize(
+        width: width,
+        height: height
+      )
+
+      return size
+    }
+  }
+
   /// Create supplementary layout attributes.
   ///
   /// - Parameters:

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -190,7 +190,7 @@
         return (collectionView.delegate as? CollectionViewFlowLayoutDelegate)?.collectionView?(collectionView,
                                                                                                layout: self,
                                                                                                referenceSizeForFooterInSection: indexPath.section)
-      }, defaultValue: headerReferenceSize).height
+      }, defaultValue: footerReferenceSize).height
 
       let width: CGFloat
       if footerReferenceSize.width > 0 {

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -397,9 +397,17 @@
     let results = cachedSupplementaryAttributes.filter({
       switch scrollDirection {
       case .vertical:
-        return (visibleRect.origin.y >= $0.min && visibleRect.origin.y <= $0.max) || $0.frame.intersects(visibleRect)
+        if visibleRect.origin.y < 0 {
+          return $0.frame.intersects(visibleRect)
+        } else {
+          return (visibleRect.origin.y >= $0.min && visibleRect.origin.y <= $0.max)
+        }
       case .horizontal:
-        return (visibleRect.origin.x >= $0.min && visibleRect.origin.x <= $0.max) || $0.frame.intersects(visibleRect)
+        if visibleRect.origin.x < 0 {
+          return $0.frame.intersects(visibleRect)
+        } else {
+          return (visibleRect.origin.x >= $0.min && visibleRect.origin.x <= $0.max)
+        }
       @unknown default:
         fatalError("Case not implemented in current implementation")
       }

--- a/Sources/Shared/Core/HorizontalBlueprintLayout.swift
+++ b/Sources/Shared/Core/HorizontalBlueprintLayout.swift
@@ -150,7 +150,7 @@
           with: sectionIndexPath
         )
         layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .header, at: sectionIndexPath)
-        layoutAttribute.zIndex = section
+        layoutAttribute.zIndex = section + numberOfItemsInSection(section)
         layoutAttribute.min = nextX
         layoutAttribute.frame.origin.x = nextX
         layoutAttribute.frame.origin.y = 0
@@ -207,7 +207,7 @@
             with: sectionIndexPath
           )
           layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .footer, at: sectionIndexPath)
-          layoutAttribute.zIndex = section
+          layoutAttribute.zIndex = section + numberOfItemsInSection(section)
           layoutAttribute.min = nextX
           layoutAttribute.frame.origin.x = 0
           layoutAttribute.frame.origin.y = contentSize.height + footerReferenceSize.height

--- a/Sources/Shared/Core/HorizontalBlueprintLayout.swift
+++ b/Sources/Shared/Core/HorizontalBlueprintLayout.swift
@@ -144,15 +144,18 @@
       var footerAttribute: SupplementaryLayoutAttributes? = nil
       let sectionIndexPath = IndexPath(item: 0, section: section)
 
-      if headerReferenceSize.height > 0 {
-        let layoutAttribute: SupplementaryLayoutAttributes = createSupplementaryLayoutAttribute(
-          ofKind: .header,
-          indexPath: sectionIndexPath,
-          atX: nextX
+      if resolveSizeForSupplementaryView(ofKind: .header, at: sectionIndexPath).height > 0 {
+        let layoutAttribute = SupplementaryLayoutAttributes(
+          forSupplementaryViewOfKind: BlueprintSupplementaryKind.header.collectionViewSupplementaryType,
+          with: sectionIndexPath
         )
+        layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .header, at: sectionIndexPath)
+        layoutAttribute.zIndex = numberOfSections
         layoutAttribute.min = nextX
-        headerAttribute = layoutAttribute
+        layoutAttribute.frame.origin.x = nextX
+        layoutAttribute.frame.origin.y = 0
         layoutAttributes.append([layoutAttribute])
+        headerAttribute = layoutAttribute
       }
 
       for item in 0..<numberOfItemsInSection(section) {
@@ -198,13 +201,15 @@
       if let previousItem = previousItem, let firstItem = firstItem {
         contentSize.width = previousItem.frame.maxX + sectionInset.right
 
-        if footerReferenceSize.height > 0 {
-          let layoutAttribute = createSupplementaryLayoutAttribute(
-            ofKind: .footer,
-            indexPath: sectionIndexPath,
-            atX: nextX
+        if resolveSizeForSupplementaryView(ofKind: .footer, at: sectionIndexPath).height > 0 {
+          let layoutAttribute = SupplementaryLayoutAttributes(
+            forSupplementaryViewOfKind: BlueprintSupplementaryKind.footer.collectionViewSupplementaryType,
+            with: sectionIndexPath
           )
+          layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .footer, at: sectionIndexPath)
+          layoutAttribute.zIndex = numberOfSections
           layoutAttribute.min = nextX
+          layoutAttribute.frame.origin.x = 0
           layoutAttribute.frame.origin.y = contentSize.height + footerReferenceSize.height
           layoutAttributes[section].append(layoutAttribute)
           footerAttribute = layoutAttribute

--- a/Sources/Shared/Core/HorizontalBlueprintLayout.swift
+++ b/Sources/Shared/Core/HorizontalBlueprintLayout.swift
@@ -150,7 +150,7 @@
           with: sectionIndexPath
         )
         layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .header, at: sectionIndexPath)
-        layoutAttribute.zIndex = numberOfSections
+        layoutAttribute.zIndex = section
         layoutAttribute.min = nextX
         layoutAttribute.frame.origin.x = nextX
         layoutAttribute.frame.origin.y = 0
@@ -207,7 +207,7 @@
             with: sectionIndexPath
           )
           layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .footer, at: sectionIndexPath)
-          layoutAttribute.zIndex = numberOfSections
+          layoutAttribute.zIndex = section
           layoutAttribute.min = nextX
           layoutAttribute.frame.origin.x = 0
           layoutAttribute.frame.origin.y = contentSize.height + footerReferenceSize.height

--- a/Sources/Shared/Core/VerticalBlueprintLayout.swift
+++ b/Sources/Shared/Core/VerticalBlueprintLayout.swift
@@ -137,11 +137,11 @@
           forSupplementaryViewOfKind: BlueprintSupplementaryKind.header.collectionViewSupplementaryType,
           with: sectionIndexPath
         )
+        layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .header, at: sectionIndexPath)
         layoutAttribute.zIndex = numberOfSections
         layoutAttribute.min = nextY
         layoutAttribute.frame.origin.x = 0
         layoutAttribute.frame.origin.y = nextY
-        layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .header, at: sectionIndexPath)
         layoutAttributes.append([layoutAttribute])
         headerAttribute = layoutAttribute
         nextY = layoutAttribute.frame.maxY
@@ -200,15 +200,17 @@
 
       if let previousItem = previousItem {
         nextY = previousItem.frame.maxY
-        if footerReferenceSize.height > 0 {
-          let layoutAttribute = createSupplementaryLayoutAttribute(
-            ofKind: .footer,
-            indexPath: sectionIndexPath,
-            atY: sectionMaxY + sectionInset.bottom
+        if resolveSizeForSupplementaryView(ofKind: .footer, at: sectionIndexPath).height > 0 {
+          let layoutAttribute = SupplementaryLayoutAttributes(
+            forSupplementaryViewOfKind: BlueprintSupplementaryKind.footer.collectionViewSupplementaryType,
+            with: sectionIndexPath
           )
-          layoutAttributes[section].append(layoutAttribute)
+          layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .footer, at: sectionIndexPath)
           layoutAttribute.zIndex = numberOfSections
-          layoutAttribute.min = headerAttribute?.frame.origin.y ?? nextY
+          layoutAttribute.min = nextY
+          layoutAttribute.frame.origin.x = 0
+          layoutAttribute.frame.origin.y = sectionMaxY + sectionInset.bottom
+          layoutAttributes[section].append(layoutAttribute)
           footerAttribute = layoutAttribute
           nextY = layoutAttribute.frame.maxY
         } else {

--- a/Sources/Shared/Core/VerticalBlueprintLayout.swift
+++ b/Sources/Shared/Core/VerticalBlueprintLayout.swift
@@ -132,15 +132,16 @@
       var footerAttribute: SupplementaryLayoutAttributes? = nil
       let sectionIndexPath = IndexPath(item: 0, section: section)
 
-      if headerReferenceSize.height > 0 {
-        let layoutAttribute = createSupplementaryLayoutAttribute(
-          ofKind: .header,
-          indexPath: sectionIndexPath,
-          atY: nextY
+      if resolveSizeForSupplementaryView(ofKind: .header, at: sectionIndexPath).height > 0 {
+        let layoutAttribute = SupplementaryLayoutAttributes(
+          forSupplementaryViewOfKind: BlueprintSupplementaryKind.header.collectionViewSupplementaryType,
+          with: sectionIndexPath
         )
         layoutAttribute.zIndex = numberOfSections
         layoutAttribute.min = nextY
-        layoutAttribute.frame.size.width = collectionView?.documentRect.width ?? headerReferenceSize.width
+        layoutAttribute.frame.origin.x = 0
+        layoutAttribute.frame.origin.y = nextY
+        layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .header, at: sectionIndexPath)
         layoutAttributes.append([layoutAttribute])
         headerAttribute = layoutAttribute
         nextY = layoutAttribute.frame.maxY

--- a/Sources/Shared/Core/VerticalBlueprintLayout.swift
+++ b/Sources/Shared/Core/VerticalBlueprintLayout.swift
@@ -199,6 +199,7 @@
       }
 
       if let previousItem = previousItem {
+        let previousY = nextY
         nextY = previousItem.frame.maxY
         if resolveSizeForSupplementaryView(ofKind: .footer, at: sectionIndexPath).height > 0 {
           let layoutAttribute = SupplementaryLayoutAttributes(
@@ -207,10 +208,12 @@
           )
           layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .footer, at: sectionIndexPath)
           layoutAttribute.zIndex = section + numberOfItemsInSection(section)
-          layoutAttribute.min = nextY
+          layoutAttribute.min = headerAttribute?.min ?? previousY
+          layoutAttribute.max = sectionMaxY + sectionInset.bottom
           layoutAttribute.frame.origin.x = 0
           layoutAttribute.frame.origin.y = sectionMaxY + sectionInset.bottom
           layoutAttributes[section].append(layoutAttribute)
+          headerAttribute?.max = sectionMaxY + sectionInset.bottom
           footerAttribute = layoutAttribute
           nextY = layoutAttribute.frame.maxY
         } else {

--- a/Sources/Shared/Core/VerticalBlueprintLayout.swift
+++ b/Sources/Shared/Core/VerticalBlueprintLayout.swift
@@ -138,7 +138,7 @@
           with: sectionIndexPath
         )
         layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .header, at: sectionIndexPath)
-        layoutAttribute.zIndex = numberOfSections
+        layoutAttribute.zIndex = section
         layoutAttribute.min = nextY
         layoutAttribute.frame.origin.x = 0
         layoutAttribute.frame.origin.y = nextY
@@ -206,7 +206,7 @@
             with: sectionIndexPath
           )
           layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .footer, at: sectionIndexPath)
-          layoutAttribute.zIndex = numberOfSections
+          layoutAttribute.zIndex = section
           layoutAttribute.min = nextY
           layoutAttribute.frame.origin.x = 0
           layoutAttribute.frame.origin.y = sectionMaxY + sectionInset.bottom

--- a/Sources/Shared/Core/VerticalBlueprintLayout.swift
+++ b/Sources/Shared/Core/VerticalBlueprintLayout.swift
@@ -138,7 +138,7 @@
           with: sectionIndexPath
         )
         layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .header, at: sectionIndexPath)
-        layoutAttribute.zIndex = section
+        layoutAttribute.zIndex = section + numberOfItemsInSection(section)
         layoutAttribute.min = nextY
         layoutAttribute.frame.origin.x = 0
         layoutAttribute.frame.origin.y = nextY
@@ -206,7 +206,7 @@
             with: sectionIndexPath
           )
           layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .footer, at: sectionIndexPath)
-          layoutAttribute.zIndex = section
+          layoutAttribute.zIndex = section + numberOfItemsInSection(section)
           layoutAttribute.min = nextY
           layoutAttribute.frame.origin.x = 0
           layoutAttribute.frame.origin.y = sectionMaxY + sectionInset.bottom

--- a/Sources/Shared/Mosaic/VerticalMosaicBlueprintLayout.swift
+++ b/Sources/Shared/Mosaic/VerticalMosaicBlueprintLayout.swift
@@ -71,7 +71,7 @@
           with: sectionIndexPath
         )
         layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .header, at: sectionIndexPath)
-        layoutAttribute.zIndex = section
+        layoutAttribute.zIndex = section + numberOfItemsInSection(section)
         layoutAttribute.min = nextY
         layoutAttribute.frame.origin.x = 0
         layoutAttribute.frame.origin.y = nextY
@@ -142,7 +142,7 @@
             with: sectionIndexPath
           )
           layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .footer, at: sectionIndexPath)
-          layoutAttribute.zIndex = section
+          layoutAttribute.zIndex = section + numberOfItemsInSection(section)
           layoutAttribute.min = headerAttribute?.frame.origin.y ?? nextY
           layoutAttribute.frame.origin.x = 0
           layoutAttribute.frame.origin.y = nextY + sectionInset.bottom

--- a/Sources/Shared/Mosaic/VerticalMosaicBlueprintLayout.swift
+++ b/Sources/Shared/Mosaic/VerticalMosaicBlueprintLayout.swift
@@ -135,6 +135,7 @@
       }
 
       if let previousAttribute = previousAttribute {
+        let previousY = nextY
         nextY = previousAttribute.frame.maxY
         if resolveSizeForSupplementaryView(ofKind: .footer, at: sectionIndexPath).height > 0 {
           let layoutAttribute = SupplementaryLayoutAttributes(
@@ -143,7 +144,8 @@
           )
           layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .footer, at: sectionIndexPath)
           layoutAttribute.zIndex = section + numberOfItemsInSection(section)
-          layoutAttribute.min = headerAttribute?.frame.origin.y ?? nextY
+          layoutAttribute.min = headerAttribute?.min ?? previousY
+          layoutAttribute.max = sectionMaxY + sectionInset.bottom
           layoutAttribute.frame.origin.x = 0
           layoutAttribute.frame.origin.y = nextY + sectionInset.bottom
           layoutAttributes[section].append(layoutAttribute)

--- a/Sources/Shared/Mosaic/VerticalMosaicBlueprintLayout.swift
+++ b/Sources/Shared/Mosaic/VerticalMosaicBlueprintLayout.swift
@@ -65,17 +65,18 @@
       var footerAttribute: SupplementaryLayoutAttributes? = nil
       let sectionIndexPath = IndexPath(item: 0, section: section)
 
-      if headerReferenceSize.height > 0 {
-        let layoutAttribute = createSupplementaryLayoutAttribute(
-          ofKind: .header,
-          indexPath: sectionIndexPath,
-          atY: nextY
+      if resolveSizeForSupplementaryView(ofKind: .header, at: sectionIndexPath).height > 0 {
+        let layoutAttribute = SupplementaryLayoutAttributes(
+          forSupplementaryViewOfKind: BlueprintSupplementaryKind.header.collectionViewSupplementaryType,
+          with: sectionIndexPath
         )
+        layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .header, at: sectionIndexPath)
+        layoutAttribute.zIndex = numberOfSections
         layoutAttribute.min = nextY
-        layoutAttribute.frame.size.width = collectionView?.documentRect.width ?? headerReferenceSize.width
+        layoutAttribute.frame.origin.x = 0
+        layoutAttribute.frame.origin.y = nextY
         layoutAttributes.append([layoutAttribute])
         headerAttribute = layoutAttribute
-        headerAttribute?.zIndex = numberOfSections
         nextY = layoutAttribute.frame.maxY
       }
 
@@ -135,17 +136,19 @@
 
       if let previousAttribute = previousAttribute {
         nextY = previousAttribute.frame.maxY
-        if footerReferenceSize.height > 0 {
-          let layoutAttribute = createSupplementaryLayoutAttribute(
-            ofKind: .footer,
-            indexPath: sectionIndexPath,
-            atY: nextY + sectionInset.bottom
+        if resolveSizeForSupplementaryView(ofKind: .footer, at: sectionIndexPath).height > 0 {
+          let layoutAttribute = SupplementaryLayoutAttributes(
+            forSupplementaryViewOfKind: BlueprintSupplementaryKind.footer.collectionViewSupplementaryType,
+            with: sectionIndexPath
           )
+          layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .footer, at: sectionIndexPath)
           layoutAttribute.zIndex = numberOfSections
           layoutAttribute.min = headerAttribute?.frame.origin.y ?? nextY
+          layoutAttribute.frame.origin.x = 0
+          layoutAttribute.frame.origin.y = nextY + sectionInset.bottom
           layoutAttributes[section].append(layoutAttribute)
-          nextY = layoutAttribute.frame.maxY
           footerAttribute = layoutAttribute
+          nextY = layoutAttribute.frame.maxY
         } else {
           nextY = nextY + sectionInset.bottom
         }

--- a/Sources/Shared/Mosaic/VerticalMosaicBlueprintLayout.swift
+++ b/Sources/Shared/Mosaic/VerticalMosaicBlueprintLayout.swift
@@ -71,7 +71,7 @@
           with: sectionIndexPath
         )
         layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .header, at: sectionIndexPath)
-        layoutAttribute.zIndex = numberOfSections
+        layoutAttribute.zIndex = section
         layoutAttribute.min = nextY
         layoutAttribute.frame.origin.x = 0
         layoutAttribute.frame.origin.y = nextY
@@ -142,7 +142,7 @@
             with: sectionIndexPath
           )
           layoutAttribute.size = resolveSizeForSupplementaryView(ofKind: .footer, at: sectionIndexPath)
-          layoutAttribute.zIndex = numberOfSections
+          layoutAttribute.zIndex = section
           layoutAttribute.min = headerAttribute?.frame.origin.y ?? nextY
           layoutAttribute.frame.origin.x = 0
           layoutAttribute.frame.origin.y = nextY + sectionInset.bottom

--- a/Tests/Shared/VerticalBlueprintLayoutTests.swift
+++ b/Tests/Shared/VerticalBlueprintLayoutTests.swift
@@ -275,8 +275,8 @@ class VerticalBlueprintLayoutTests: XCTestCase {
   }
 
   func testVerticalLayoutAttributesWithHeaderAndFooter() {
-    verticalLayout.headerReferenceSize = CGSize(width: 100, height: 100)
-    verticalLayout.footerReferenceSize = CGSize(width: 100, height: 100)
+    verticalLayout.headerReferenceSize = CGSize(width: collectionView.frame.width, height: 100)
+    verticalLayout.footerReferenceSize = CGSize(width: collectionView.frame.width, height: 100)
     verticalLayout.prepare()
 
     let expectedHeaderAndFooterSize: CGSize = .init(width: 200, height: 100)


### PR DESCRIPTION
This implements the delegate methods for header/footer reference sizes so they can be provided just like we do for the items.

This will allow users to provide dynamic heights for headers and footers if they wish.