### PR TITLE
Fix/exclude empty sections

### DIFF
--- a/Blueprints.podspec
+++ b/Blueprints.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Blueprints"
   s.summary          = "A collection of flow layouts that is meant to make your life easier."
-  s.version          = "0.12.2"
+  s.version          = "0.13.0"
   s.homepage         = "https://github.com/zenangst/Blueprints"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/Shared/Core/HorizontalBlueprintLayout.swift
+++ b/Sources/Shared/Core/HorizontalBlueprintLayout.swift
@@ -134,6 +134,10 @@
     var widthOfSection: CGFloat = 0
 
     for section in 0..<sections {
+      let numberOfItems = numberOfItemsInSection(section)
+      guard numberOfItems > 0 else {
+        continue
+      }
       widthOfSection = 0
       var firstItem: LayoutAttributes? = nil
       var previousItem: LayoutAttributes? = nil
@@ -142,7 +146,6 @@
       let sectionIndexPath = IndexPath(item: 0, section: section)
       let sectionsMinimumInteritemSpacing = resolveMinimumInteritemSpacing(forSectionAt: section)
       let sectionsMinimumLineSpacing = resolveMinimumLineSpacing(forSectionAt: section)
-      let numberOfItems = numberOfItemsInSection(section)
       let headerSize = resolveSizeForSupplementaryView(ofKind: .header, at: sectionIndexPath)
 
       if headerSize.height > 0 {

--- a/Sources/Shared/Core/VerticalBlueprintLayout.swift
+++ b/Sources/Shared/Core/VerticalBlueprintLayout.swift
@@ -118,12 +118,15 @@ import UIKit
     var nextY: CGFloat = 0
 
     for section in 0..<sections {
+      let numberOfItems = numberOfItemsInSection(section)
+      guard numberOfItems > 0 else {
+        continue
+      }
       var previousAttribute: LayoutAttributes? = nil
       var headerAttribute: SupplementaryLayoutAttributes? = nil
       let sectionIndexPath = IndexPath(item: 0, section: section)
       let sectionsMinimumInteritemSpacing = resolveMinimumInteritemSpacing(forSectionAt: section)
       let sectionsMinimumLineSpacing = resolveMinimumLineSpacing(forSectionAt: section)
-      let numberOfItems = numberOfItemsInSection(section)
       let headerSize = resolveSizeForSupplementaryView(ofKind: .header, at: sectionIndexPath)
 
       if headerSize.height > 0 {


### PR DESCRIPTION
Empty sections should be excluded like they where previously. This stops empty space from been added where headers/footers would normally be when cells are present.

Would only be present for unusual data sources where empty sections are included, although maybe in the future we would want to look at adding the headers/footers for empty sections. 🤷‍♂️