### PR TITLE
Update default number of sections

### DIFF
--- a/Blueprints.podspec
+++ b/Blueprints.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Blueprints"
   s.summary          = "A collection of flow layouts that is meant to make your life easier."
-  s.version          = "0.13.1"
+  s.version          = "0.13.2"
   s.homepage         = "https://github.com/zenangst/Blueprints"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }

--- a/Sources/Shared/Core/BlueprintLayout.swift
+++ b/Sources/Shared/Core/BlueprintLayout.swift
@@ -35,7 +35,7 @@
   public var contentSize: CGSize = .zero
   /// The number of sections in the collection view.
   var numberOfSections: Int { return resolveCollectionView({ $0.dataSource?.numberOfSections?(in: $0) },
-                                                           defaultValue: 1) }
+                                                           defaultValue: 0) }
   /// A layout animator object, defaults to `DefaultLayoutAnimator`.
   var animator: BlueprintLayoutAnimator
   var supplementaryWidth: CGFloat = 0


### PR DESCRIPTION
This should be 0 not 1 as we can't assume a value. It can cause issues if the collection view is using headers and footers, as the collection view attempts to dequeue a header/footer that has yet to be registered. fixes #139 