### PR TITLE
Swift Package Manager support for iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.0
+import PackageDescription
+
+let package = Package(
+    name: "Blueprints",
+    platforms: [
+        .iOS(.v8),
+        .tvOS(.v9_2),
+        .macOS(.v10_11)
+    ]
+    products: [
+        .library(name: "Blueprints", targets: ["Blueprints"]),
+    ],
+    targets: [
+         .target(
+            name: "Blueprints",
+            path: "Sources",
+            exclude: [
+                "Sources/macOS"
+            ]
+         )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -7,17 +7,14 @@ let package = Package(
         .iOS(.v8),
         .tvOS(.v9_2),
         .macOS(.v10_11)
-    ]
+    ],
     products: [
         .library(name: "Blueprints", targets: ["Blueprints"]),
     ],
     targets: [
          .target(
             name: "Blueprints",
-            path: "Sources",
-            exclude: [
-                "Sources/macOS"
-            ]
+            path: "Sources"
          )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,15 +16,17 @@ let package = Package(
          .target(
             name: "Blueprints",
             path: "Sources",
-            exclude: [
-                "Sources/macOS"
+            sources: [
+                "Sources/Shared",
+                "Sources/iOS+tvOS"
             ]
          ),
          .target(
             name: "BlueprintsMac",
             path: "Sources",
-            exclude: [
-                "Sources/iOS+tvOS"
+            sources: [
+                "Sources/Shared",
+                "Sources/macOS"
             ]
          )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -17,16 +17,16 @@ let package = Package(
             name: "Blueprints",
             path: "Sources",
             sources: [
-                "Sources/Shared",
-                "Sources/iOS+tvOS"
+                "Shared",
+                "iOS+tvOS"
             ]
          ),
          .target(
             name: "BlueprintsMac",
             path: "Sources",
             sources: [
-                "Sources/Shared",
-                "Sources/macOS"
+                "Shared",
+                "macOS"
             ]
          )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "Blueprints",
     platforms: [
         .iOS(.v8),
-        .tvOS(.v9_2),
+        .tvOS(.v9),
         .macOS(.v10_11)
     ],
     products: [

--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,7 @@ let package = Package(
         .macOS(.v10_11)
     ],
     products: [
-        .library(name: "Blueprints", targets: ["Blueprints"]),
-        .library(name: "BlueprintsMac", targets: ["BlueprintsMac"])
+        .library(name: "Blueprints", targets: ["Blueprints"])
     ],
     targets: [
          .target(
@@ -19,14 +18,6 @@ let package = Package(
             sources: [
                 "Shared",
                 "iOS+tvOS"
-            ]
-         ),
-         .target(
-            name: "BlueprintsMac",
-            path: "Sources",
-            sources: [
-                "Shared",
-                "macOS"
             ]
          )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -9,12 +9,22 @@ let package = Package(
         .macOS(.v10_11)
     ],
     products: [
-        .library(name: "Blueprints", targets: ["Blueprints"]),
+        .library(name: "Blueprints", targets: ["Blueprints", "BlueprintsMac"]),
     ],
     targets: [
          .target(
             name: "Blueprints",
-            path: "Sources"
+            path: "Sources",
+            exclude: [
+                "Sources/macOS"
+            ]
+         ),
+         .target(
+            name: "BlueprintsMac",
+            path: "Sources",
+            exclude: [
+                "Sources/iOS+tvOS"
+            ]
          )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,8 @@ let package = Package(
         .macOS(.v10_11)
     ],
     products: [
-        .library(name: "Blueprints", targets: ["Blueprints", "BlueprintsMac"]),
+        .library(name: "Blueprints", targets: ["Blueprints"]),
+        .library(name: "BlueprintsMac", targets: ["BlueprintsMac"])
     ],
     targets: [
          .target(


### PR DESCRIPTION
This PR adds the ability to installs Blueprints as a Swift Package on iOS/tvOS. Due to project structure macOS is not yet supported.